### PR TITLE
fix: commented out new database extensions

### DIFF
--- a/services/database/server/schemas/v1_schema.sql
+++ b/services/database/server/schemas/v1_schema.sql
@@ -1,13 +1,13 @@
 CREATE EXTENSION pgcrypto;
-CREATE EXTENSION pg_stat_statements;
-CREATE EXTENSION timescaledb;
-CREATE EXTENSION timescaledb_toolkit;
-CREATE EXTENSION timescaledb_toolkit;
-CREATE EXTENSION pg_textsearch;
-CREATE EXTENSION pg_audit;
-CREATE EXTENSION pg_cron;
-CREATE EXTENSION pgrouting;
-CREATE EXTENSION unit;
+-- CREATE EXTENSION pg_stat_statements;
+-- CREATE EXTENSION timescaledb;
+-- CREATE EXTENSION timescaledb_toolkit;
+-- CREATE EXTENSION timescaledb_toolkit;
+-- CREATE EXTENSION pg_textsearch;
+-- CREATE EXTENSION pg_audit;
+-- CREATE EXTENSION pg_cron;
+-- CREATE EXTENSION pgrouting;
+-- CREATE EXTENSION unit;
 
 CREATE SCHEMA bible;
 CREATE SCHEMA nlp;


### PR DESCRIPTION
Since the extensions aren't loaded / downloaded on database it will break during execution