### PR TITLE
refactor: Tokenisable Nodes

### DIFF
--- a/services/ingestor/ingestor.py
+++ b/services/ingestor/ingestor.py
@@ -9,9 +9,11 @@ from ingestor.translation import Translation
 from manager.managerhandler import ManagerHandler
 
 class Ingestor:
-    def __init__(self, dbl_id = None, agreement_id = None):
-        self.manager = ManagerHandler()
-        self.manager.get_obj().set_default_bucket("bible-dbl-raw")
+    def __init__(self, manager: ManagerHandler = None, dbl_id = None, agreement_id = None):
+        self.manager = manager
+        if manager == None:
+            self.manager = ManagerHandler()
+            self.manager.get_obj().set_default_bucket("bible-dbl-raw")
 
         self.dbl_id = dbl_id
         self.agreement_id = agreement_id

--- a/services/ingestor/ingestor.py
+++ b/services/ingestor/ingestor.py
@@ -9,9 +9,12 @@ from ingestor.translation import Translation
 from manager.managerhandler import ManagerHandler
 
 class Ingestor:
-    def __init__(self):
+    def __init__(self, dbl_id = None, agreement_id = None):
         self.manager = ManagerHandler()
         self.manager.get_obj().set_default_bucket("bible-dbl-raw")
+
+        self.dbl_id = dbl_id
+        self.agreement_id = agreement_id
 
         self.env = self.manager.get_env()
         self.db = self.manager.get_db()
@@ -121,27 +124,19 @@ class Ingestor:
                 print("     Already logged in") # Assumes that we couldn't find email field in link means we are logged in already
 
             translations = self.db.fetch_all("""SELECT dbl_id, agreement_id FROM bible.DBLInfo;""")
-            # translations = (
-            #     "6bab4d6c61b31b80-252265".split("-"), # introduces PSA151
-            #     "32664dc3288a28df-265137".split("-"),
-            #     "f72b840c855f362c-240017".split("-"),
-            #     # "65bfdebd704a8324-250819".split("-"),
-            #     "06125adad2d5898a-240014".split("-"),
-            #     "04da588535d2f823-240018".split("-"),
-            #     "72f4e6dc683324df-278101".split("-")
-            #     # "c114c33098c4fef1-252266".split("-")
-            # )
 
-            for dbl_id, agreement_id in translations:
+            for i, dbl_id, agreement_id in enumerate(translations):
+                if self.dbl_id != None and self.agreement_id != None:
+                    if i == 0:
+                        dbl_id = self.dbl_id
+                        agreement_id = self.agreement_id
+                    else:
+                        break
 
                 translation_id = self.get_translation(dbl_id, agreement_id)
                 if translation_id == -1:
                     print(f"❌ Translation {dbl_id}-{agreement_id} already exists! Skipping ...")
                     continue # Skip because its already in our system
-
-                # 32664dc3288a28df-265137
-                # dbl_id = "32664dc3288a28df"
-                # agreement_id = 265137
 
                 print(f"\n\n✅ Starting Translation {dbl_id}-{agreement_id} Processing!")
 
@@ -153,7 +148,7 @@ class Ingestor:
 
                 # Wait for the download button to appear
                 # Inspect the page and adjust the selector to match the button
-                page.wait_for_selector("button:has-text('Download')")  
+                page.wait_for_selector("button:has-text('Download All')")  
 
                 zip_button = page.query_selector("button:has-text('Download All')")
                 if zip_button:
@@ -197,15 +192,11 @@ class Ingestor:
                         download = download_info.value
                         download.save_as(os.path.join(folder_path, filename))
 
-                        # print(f"✅ Downloaded {filename} → {folder_path}")
-
                     new_path = Path(self.download_path) / download_folder_name
                     
                     print(f"✅ Downloaded {len(file_buttons)} Audio Files: {new_path}")
 
                     Translation(self.manager, "audio", new_path, url, translation_id, dbl_id, agreement_id)
-
-                # break
 
             browser.close()
 

--- a/services/ingestor/ingestor.py
+++ b/services/ingestor/ingestor.py
@@ -9,7 +9,7 @@ from ingestor.translation import Translation
 from manager.managerhandler import ManagerHandler
 
 class Ingestor:
-    def __init__(self, manager: ManagerHandler = None, dbl_id = None, agreement_id = None):
+    def __init__(self, manager: ManagerHandler = None, dbl_id = None, agreement_id = None, all_translations: list = None):
         self.manager = manager
         if manager == None:
             self.manager = ManagerHandler()
@@ -17,6 +17,7 @@ class Ingestor:
 
         self.dbl_id = dbl_id
         self.agreement_id = agreement_id
+        self.all_translations = all_translations
 
         self.env = self.manager.get_env()
         self.db = self.manager.get_db()
@@ -125,7 +126,11 @@ class Ingestor:
             else:
                 print("     Already logged in") # Assumes that we couldn't find email field in link means we are logged in already
 
-            translations = self.db.fetch_all("""SELECT dbl_id, agreement_id FROM bible.DBLInfo;""")
+            translations = None
+            if self.all_translations == None:
+                translations = self.db.fetch_all("""SELECT dbl_id, agreement_id FROM bible.DBLInfo;""")
+            else:
+                translations = self.all_translations
 
             for i, dbl_id, agreement_id in enumerate(translations):
                 if self.dbl_id != None and self.agreement_id != None:

--- a/services/ingestor/ingestor.py
+++ b/services/ingestor/ingestor.py
@@ -132,7 +132,7 @@ class Ingestor:
             else:
                 translations = self.all_translations
 
-            for i, dbl_id, agreement_id in enumerate(translations):
+            for i, (dbl_id, agreement_id) in enumerate(translations):
                 if self.dbl_id != None and self.agreement_id != None:
                     if i == 0:
                         dbl_id = self.dbl_id
@@ -208,4 +208,5 @@ class Ingestor:
             browser.close()
 
 if __name__ == "__main__":
-    Ingestor()
+    # Ingestor()
+    Ingestor(dbl_id="7142879509583d59", agreement_id="240016")

--- a/services/ingestor/nodes.py
+++ b/services/ingestor/nodes.py
@@ -9,11 +9,14 @@ if TYPE_CHECKING:
 class Nodes:
     SQL = {
         "new_node": """
-            INSERT INTO bible.nodes (node_text, node_type, code, sid, eid, vid, style, number, caller, closed, version, strong, loc, parent_node_id, index_in_parent, book_map_id, canonical_path, align, translation_id) 
+            INSERT INTO bible.nodes (node_text, node_type, code, sid, eid, vid, style, number, caller, closed, version, strong, loc, parent_node_id, index_in_parent, book_map_id, canonical_path, align, translation_id, is_tokenisable) 
             VALUES %s;
         """,
         "max_node_count": """
             SELECT COALESCE(MAX(id), 0) FROM bible.nodes;
+        """,
+        "is_para_versetext": """
+            SELECT versetext FROM bible.styles WHERE style = %s AND source_file_id = %s
         """
     }
 
@@ -29,6 +32,7 @@ class Nodes:
         # Initialise variables 
         self.book_soup = BeautifulSoup(book_xml, "xml")
         self.book_map_id = self.this_book.get_book_map_id()
+        self.book_style_file_id = self.this_translation.get_file("styles")
         self.translation_id = self.this_translation.get_translation_id()
 
         self.created_nodes = {
@@ -60,7 +64,7 @@ class Nodes:
             node_id = node_id_counter + node_id_offset # since i will be 0, want to start at 1 instead + offset from database to say this new node is
             node_type = None
             
-            this_node = [None] * 19 # create mutable list of length 17
+            this_node = [None] * 20 # create mutable list of length 17
 
             if isinstance(node, Tag):
                 node_type =     node.name
@@ -91,6 +95,14 @@ class Nodes:
 
                 this_node[0] = str(node) # node_text, 0
                 this_node[1] = node_type # node_type, 1
+
+                for node_parent in node.parents:
+                    if node_parent.name == "note":
+                        continue # if text_node inside a note node, then skip, never tokenisable
+                    elif node_parent.name == "para":
+                        # if inside a para node
+                        parent_style = node_parent.get("style")
+                        this_node[19] = self.db.fetch_clean_one(self.SQL.get("is_para_versetext"), (parent_style, self.book_style_file_id)) # is_tokenisable, 19
 
             # ------ Skip empty nodes
             if all(x is None for x in this_node) and node_type != "table":

--- a/services/ingestor/nodes.py
+++ b/services/ingestor/nodes.py
@@ -98,12 +98,12 @@ class Nodes:
 
                 for node_parent in node.parents:
                     if node_parent.name == "note":
-                        continue # if text_node inside a note node, then skip, never tokenisable
+                        break # if text_node inside a note node, then skip, never tokenisable
                     elif node_parent.name == "para":
                         # if inside a para node
                         parent_style = node_parent.get("style")
                         this_node[19] = self.db.fetch_clean_one(self.SQL.get("is_para_versetext"), (parent_style, self.book_style_file_id)) # is_tokenisable, 19
-                        continue
+                        break
 
             # ------ Skip empty nodes
             if all(x is None for x in this_node) and node_type != "table":

--- a/services/ingestor/nodes.py
+++ b/services/ingestor/nodes.py
@@ -103,6 +103,7 @@ class Nodes:
                         # if inside a para node
                         parent_style = node_parent.get("style")
                         this_node[19] = self.db.fetch_clean_one(self.SQL.get("is_para_versetext"), (parent_style, self.book_style_file_id)) # is_tokenisable, 19
+                        continue
 
             # ------ Skip empty nodes
             if all(x is None for x in this_node) and node_type != "table":

--- a/services/ingestor/translation.py
+++ b/services/ingestor/translation.py
@@ -39,7 +39,13 @@ class Translation:
         self.translation_name = None
         self.bible_structure_info = None
 
-        self.style_file_id = None
+        self.files = {
+            "metadata": None,
+            "license": None,
+            "ldml": None,
+            "versification": None,
+            "styles": None,
+        }
         self.style_dict = {}
 
         # Initialise logfile
@@ -156,6 +162,9 @@ class Translation:
     
     def get_style_dict(self):
         return self.style_dict
+    
+    def get_file(self, type):
+        return self.files.get(type)
     
     def get_bible_structure_info(self):
         structure = self.bible_structure_info
@@ -317,6 +326,14 @@ class Translation:
         if ldml_file is not None:
             ldml_file_id = self.get_support_files(file_location, object_start, ldml_file, "application/xml")
 
+        self.files = {
+            "metadata": self.get_support_files(file_location, object_start, "metadata.xml", "application/xml"),
+            "license": self.get_support_files(file_location, object_start, "license.xml", "application/xml"),
+            "ldml": ldml_file_id,
+            "versification": self.get_support_files(file_location, object_start, "release/versification.vrs", "application/xml"),
+            "styles": self.get_support_files(file_location, object_start, "release/styles.xml", "application/xml"),
+        }
+
         # Update this information for translation in database
         self.db.execute("""
             UPDATE bible.translations
@@ -331,11 +348,11 @@ class Translation:
         """, (
             self.revision, 
             revision_note, 
-            self.get_support_files(file_location, object_start, "metadata.xml", "application/xml"),
-            self.get_support_files(file_location, object_start, "license.xml", "application/xml"),
-            ldml_file_id,
-            self.get_support_files(file_location, object_start, "release/versification.vrs", "application/xml"),
-            self.get_support_files(file_location, object_start, "release/styles.xml", "application/xml"),
+            self.files["metadata"],
+            self.files["license"],
+            self.files["ldml"],
+            self.files["versification"],
+            self.files["styles"],
             self.translation_id
         ))
         self.log.log_to_file(f"Updated Translation Entry File IDs", "TRANSLATION", "TRACE")

--- a/services/ingestor/translation.py
+++ b/services/ingestor/translation.py
@@ -49,7 +49,7 @@ class Translation:
         self.style_dict = {}
 
         # Initialise logfile
-        self.log = self.manager.create_log(f"{self.translation_id}-{self.translation_title}")
+        self.log = self.manager.create_log_in_folder(f"{self.translation_id}-{self.translation_title}", ["logs", "ingestor"])
         self.log.set_logging_level(2)
 
         self.log.log_to_file(f"TRANSLATION: [{self.dbl_id}-{self.agreement_id}] with ID [{self.translation_id}]", "TRANSLATION", "INFO")

--- a/services/manager/dbmanager.py
+++ b/services/manager/dbmanager.py
@@ -91,6 +91,10 @@ class DBManager:
         self.cur.execute(query, params)
         return self.cur.fetchall()
     
+    def fetch_all_single(self, query, params=None):
+        self.cur.execute(query, params)
+        return [row[0] for row in self.cur.fetchall()]
+    
     def set_chunks(self, new_chunk):
         self.CHUNK = new_chunk
     

--- a/services/manager/dbmanager.py
+++ b/services/manager/dbmanager.py
@@ -42,7 +42,7 @@ class DBManager:
         """)
         
         if is_init:
-            print("Database Already Initialised!")
+            # print("Database Already Initialised!")
             return 
 
         db_server_script_path = Path(__file__).parents[2] / "services" / "database" / "server"

--- a/services/manager/logmanager.py
+++ b/services/manager/logmanager.py
@@ -21,7 +21,7 @@ class LogManager():
     def __init__(
             self, manager: "ManagerHandler" = None, 
             default_log_path=None, 
-            default_log_folder=None, 
+            default_log_folder:list=None, 
             log_file_name=None, 
             log_file_extension="log", 
             log_level=2,
@@ -38,7 +38,7 @@ class LogManager():
         elif default_log_folder != None:
             self.set_default_log_folder(default_log_folder, False)
         else:
-            self.set_default_log_folder("logs", False)
+            self.set_default_log_folder(["logs"], False)
 
         self.log_file_extension = log_file_extension
 
@@ -79,8 +79,10 @@ class LogManager():
         if update:
             self.update_log_file()
 
-    def set_default_log_folder(self, log_folder, update=True):
-        default_log_path = Path(__file__).parents[2] / log_folder
+    def set_default_log_folder(self, log_folders, update=True):
+        default_log_path = Path(__file__).parents[2]
+        for folder in log_folders:
+            default_log_path = default_log_path / folder
 
         try:
             os.makedirs(default_log_path)

--- a/services/manager/logmanager.py
+++ b/services/manager/logmanager.py
@@ -45,7 +45,9 @@ class LogManager():
         self.log_file_name = log_file_name
 
         if log_file_name == None:
-            raise ValueError("Missing required parameter: log_file_name.")
+            dt = datetime.now()
+            # dt.strftime("%Y-%m-%d %H:%M:%S") => 2025-12-09 20:15:42
+            log_file_name = dt.strftime("%Y%m%d%H%M%S")
         
         self.log_file = self.log_path / f"{self.log_file_name}.{self.log_file_extension}"
         self.disable_log = disable_log

--- a/services/manager/managerhandler.py
+++ b/services/manager/managerhandler.py
@@ -24,6 +24,11 @@ class ManagerHandler:
         log_manager = LogManager(manager=self, log_file_name=file_name)
         self.logs[file_name] = log_manager
         return log_manager
+    
+    def create_log_in_folder(self, file_name, folders:list):
+        log_manager = LogManager(manager=self, log_file_name=file_name, default_log_folder=folders)
+        self.logs[file_name] = log_manager
+        return log_manager
 
     def return_log(self, file_name):
         requested_log = self.logs.get(file_name)

--- a/services/manager/objectmanager.py
+++ b/services/manager/objectmanager.py
@@ -15,6 +15,7 @@ class ObjectManager:
             self.env = self.this_manager.get_env()
 
         config = self.env.get_minio_config()
+        self.db = self.this_manager.get_db()
 
         # Passes Minio client connection on to the MinioUSXUpload class
         self.client = Minio(
@@ -56,12 +57,14 @@ class ObjectManager:
 
         return self.client.list_buckets()
 
-    def stream_file(self, object_name):
+    def stream_file(self, object_name, bucket=None):
+        if bucket == None:
+            bucket = self.bucket
         # Get file
         response = None 
         try:
             response = self.client.get_object(
-                bucket_name=self.bucket,
+                bucket_name=bucket,
                 object_name=object_name,
             )
             # Read the data as bytes, then decode as UTF-8
@@ -71,6 +74,12 @@ class ObjectManager:
             if response:
                 response.close()
                 response.release_conn()
+
+    def stream_file_from_file_id(self, file_id):
+        file_object_name, file_bucket = self.db.fetch_one("""
+            SELECT file_path AS object_name, bucket FROM bible.files WHERE id = %s
+        """, (file_id,))
+        return self.stream_file(file_object_name, file_bucket)
 
     def upload_file(self, object_name, file_path, content_type, bucket=None):
         if bucket == None:

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -689,15 +689,16 @@ class Assembler:
         self.assemble_text("REF", valid_nodes, self.is_nlp)
     
     def add_detail(self):
-        self.set_xml()
-        self.get_strongs(self.scope)
+        if self.details != {}:
+            self.set_xml()
+            self.get_strongs(self.scope)
 
-        self.get_entities()
-        self.get_llema()
-        self.get_quotes()
-        self.get_cross_refs()
-        self.get_foot_notes()
-        self.get_user_notes()
+            self.get_entities()
+            self.get_llema()
+            self.get_quotes()
+            self.get_cross_refs()
+            self.get_foot_notes()
+            self.get_user_notes()
 
     def get_file_id(self):
         book_map_id = self.details["book"]

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -204,7 +204,18 @@ class Assembler:
             SELECT id
             FROM bible.nodes
             WHERE canonical_path = %s AND translation_id = %s
-        """
+        """,
+        # Helper Update Queries
+        "update_node_offsets": """
+            UPDATE bible.nodes 
+            SET chapter_start_offset = %s, chapter_end_offset = %s
+            WHERE id = %s;
+        """,
+        "update_chapter_occurence_text": """
+            UPDATE bible.chapteroccurences 
+            SET reconstructed_text = %s
+            WHERE id = %s;
+        """,
     }
 
     def __init__(self, manager: ManagerHandler = None, occurence_id=None, node_id=None, canonical_path=None, ref=None, scope=None, translation_id=None):
@@ -303,6 +314,29 @@ class Assembler:
         
         # Log the resulted reconstruction - if it was successful (no error flagged)
         self.log.log_to_file(f"Reconstruction: [\n{self.text}\n]", "OCCURENCE", "DEBUG")
+
+    def assemble_text(self, source: str, tokenisable_nodes: list, update_offsets:bool = False):
+        self.log.log_to_file(f"Tokens for Reconstruction: f{tokenisable_nodes}", source, "DEBUG")
+
+        temp_offsets = []
+
+        for node in tokenisable_nodes:
+            node_id = node[0]
+            node_text = node[1]
+            self.nodes.append(node_id)
+
+            start = len(self.text)
+            self.text += node_text
+            end = len(self.text)
+
+            temp_offsets.append((start, end, node_id))
+
+        if update_offsets:
+            # Update start, end offsets for node
+            self.db.bulk_insert(self.SQL.get("update_node_offsets"), temp_offsets)
+
+            if self.details.get("scope") == "chapter":
+                self.db.execute(self.SQL.get("update_chapter_occurence_text"), (self.text, self.details.get("chapter")))
     
     def reconstruct_occurence(self, scope, occurence_id):
         valid_nodes = None
@@ -369,12 +403,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
         
-        self.log.log_to_file(f"Tokens for Reconstruction: {valid_nodes}", "OCCURENCE", "DEBUG")
-        for node in valid_nodes:
-            node_id = node[0]
-            node_text = node [1]
-            self.nodes.append(node_id)
-            self.text += node_text
+        self.assemble_text("OCCURENCE", valid_nodes)
 
     def reconstruct_from_node_id(self, scope, node_id):
         valid_nodes = None
@@ -448,12 +477,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.log.log_to_file(f"Tokens for Reconstruction: {valid_nodes}", "NODE_ID", "DEBUG")
-        for node in valid_nodes:
-            node_id = node[0]
-            node_text = node [1]
-            self.nodes.append(node_id)
-            self.text += node_text
+        self.assemble_text("NODE_ID", valid_nodes)
 
     def reconstruct_from_node_path(self, scope, translation_id, canonical_path):
         valid_nodes = None
@@ -525,12 +549,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.log.log_to_file(f"Tokens for Reconstruction: {valid_nodes}", "CANONICAL_PATH", "DEBUG")
-        for node in valid_nodes:
-            node_id = node[0]
-            node_text = node [1]
-            self.nodes.append(node_id)
-            self.text += node_text
+        self.assemble_text("CANONICAL_PATH", valid_nodes)
 
     def reconstruct_from_ref(self, translation_id, ref:str):
         # Find if GEN, GEN 1, GEN 1:1 => Based on that change query
@@ -601,12 +620,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.log.log_to_file(f"Tokens for Reconstruction: f{valid_nodes}", "REF", "DEBUG")
-        for node in valid_nodes:
-            node_id = node[0]
-            node_text = node [1]
-            self.nodes.append(node_id)
-            self.text += node_text
+        self.assemble_text("REF", valid_nodes)
     
     # Perhaps function to help build on nodes, to display strongs if available?
 

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -216,6 +216,9 @@ class Assembler:
             SET reconstructed_text = %s
             WHERE id = %s;
         """,
+        "get_strongs_in_range": """
+
+        """
     }
 
     def __init__(
@@ -265,6 +268,9 @@ class Assembler:
 
             # "node": None,               # bible.nodes -> id
             # "node_path": None           # bible.nodes -> canonical_path
+
+            # "xml": None,                # Get from book_xml file
+            # "strongs": None,            # bible.nodes -> strongs (unique set in range)
         }
 
         try:
@@ -637,6 +643,29 @@ class Assembler:
         self.assemble_text("REF", valid_nodes, self.is_nlp)
     
     # Perhaps function to help build on nodes, to display strongs if available?
+    def set_xml(self):
+        pass
+
+    def get_strongs(self):
+        pass
+    
+    def get_entities(self):
+        pass
+    
+    def get_llema(self):
+        pass
+    
+    def get_quotes(self):
+        pass
+    
+    def get_cross_refs(self):
+        pass
+    
+    def get_foot_notes(self):
+        pass
+    
+    def get_user_notes(self):
+        pass
 
 # Used for TESTING
 if __name__ == "__main__":

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -218,7 +218,13 @@ class Assembler:
         """,
     }
 
-    def __init__(self, manager: ManagerHandler = None, occurence_id=None, node_id=None, canonical_path=None, ref=None, scope=None, translation_id=None):
+    def __init__(
+            self, 
+            manager: ManagerHandler = None, 
+            occurence_id=None, node_id=None, canonical_path=None, ref=None, scope=None, translation_id=None, 
+            is_nlp=False
+        ):
+        
         self.occurence_id   = occurence_id
         self.node_id        = node_id
         self.canonical_path = canonical_path
@@ -226,6 +232,8 @@ class Assembler:
         self.scope          = scope
 
         self.translation_id = translation_id
+
+        self.is_nlp         = is_nlp
 
         self.manager = manager
         if manager == None:
@@ -403,7 +411,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
         
-        self.assemble_text("OCCURENCE", valid_nodes)
+        self.assemble_text("OCCURENCE", valid_nodes, self.is_nlp)
 
     def reconstruct_from_node_id(self, scope, node_id):
         valid_nodes = None
@@ -477,7 +485,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.assemble_text("NODE_ID", valid_nodes)
+        self.assemble_text("NODE_ID", valid_nodes, self.is_nlp)
 
     def reconstruct_from_node_path(self, scope, translation_id, canonical_path):
         valid_nodes = None
@@ -549,7 +557,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.assemble_text("CANONICAL_PATH", valid_nodes)
+        self.assemble_text("CANONICAL_PATH", valid_nodes, self.is_nlp)
 
     def reconstruct_from_ref(self, translation_id, ref:str):
         # Find if GEN, GEN 1, GEN 1:1 => Based on that change query
@@ -620,7 +628,7 @@ class Assembler:
                 self.set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.assemble_text("REF", valid_nodes)
+        self.assemble_text("REF", valid_nodes, self.is_nlp)
     
     # Perhaps function to help build on nodes, to display strongs if available?
 

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -1,4 +1,4 @@
-
+import traceback
 
 # Responsible for helping me test token queries and trying to reassemble fragments in a way I might request it from the server
 
@@ -224,7 +224,7 @@ class Assembler:
             occurence_id=None, node_id=None, canonical_path=None, ref=None, scope=None, translation_id=None, 
             is_nlp=False
         ):
-        
+
         self.occurence_id   = occurence_id
         self.node_id        = node_id
         self.canonical_path = canonical_path
@@ -267,7 +267,13 @@ class Assembler:
             # "node_path": None           # bible.nodes -> canonical_path
         }
 
-        self.assemble()
+        try:
+            self.assemble()
+        except Exception as e:
+            self.log.log_to_file("No Tokenisable Nodes for assembly suspected!", "ASSEMBLER", "WARN")
+
+            error_message = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
+            self.log.log_to_file(error_message, "ASSEMBLER", "ERROR")
     
     def get_details(self, detail=None):
         if detail == None:

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -342,9 +342,6 @@ class Assembler:
         self.details["scope"]   = self.scope
         self.details["text"]    = self.text
         self.details["nodes"]   = self.nodes
-
-        self.set_xml()
-        self.get_strongs(self.scope)
         
         # Log the resulted reconstruction - if it was successful (no error flagged)
         self.log.log_to_file(f"Reconstruction: [\n{self.text}\n]", "OCCURENCE", "DEBUG")
@@ -656,6 +653,17 @@ class Assembler:
 
         self.assemble_text("REF", valid_nodes, self.is_nlp)
     
+    def add_detail(self):
+        self.set_xml()
+        self.get_strongs(self.scope)
+
+        self.get_entities()
+        self.get_llema()
+        self.get_quotes()
+        self.get_cross_refs()
+        self.get_foot_notes()
+        self.get_user_notes()
+
     def get_file_id(self):
         book_map_id = self.details["book"]
         file_id = self.db.fetch_clean_one("""

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -1,4 +1,6 @@
 import traceback
+import re
+from bs4 import BeautifulSoup
 
 # Responsible for helping me test token queries and trying to reassemble fragments in a way I might request it from the server
 
@@ -254,6 +256,7 @@ class Assembler:
         self.db = self.manager.get_db()
         self.log = self.manager.create_log_in_folder("assembler", ["logs", "assembler"])
         self.log.set_logging_level(2)
+        self.obj = self.manager.get_obj()
 
         self.nodes  = [] # Represents all (tokenisable) nodes used to reconstruct context
         self.text   = ""
@@ -340,6 +343,7 @@ class Assembler:
         self.details["text"]    = self.text
         self.details["nodes"]   = self.nodes
 
+        self.set_xml()
         self.get_strongs(self.scope)
         
         # Log the resulted reconstruction - if it was successful (no error flagged)
@@ -652,9 +656,63 @@ class Assembler:
 
         self.assemble_text("REF", valid_nodes, self.is_nlp)
     
+    def get_file_id(self):
+        book_map_id = self.details["book"]
+        file_id = self.db.fetch_clean_one("""
+            SELECT file_id FROM bible.booktofile WHERE id = %s;
+        """, (book_map_id,))
+        self.details["file"] = file_id
+        return file_id
+
     # Perhaps function to help build on nodes, to display strongs if available?
     def set_xml(self):
-        pass
+        print(self.get_file_id())
+        book_xml = BeautifulSoup(self.obj.stream_file_from_file_id(self.get_file_id()), "xml")
+
+        ref_text = None
+
+        if self.scope != "book":
+            ref = self.details["ref"]
+
+            start_tag = book_xml.find(self.scope, sid=ref)
+            end_tag = book_xml.find(self.scope, eid=ref)
+
+            search_string = f"{start_tag}.*{end_tag}"
+            ref_found = re.search(search_string, str(book_xml), re.DOTALL)
+
+            # In case of WLC for example, Malachi 4 doesn't exist, so skip over chapter
+            #       if it doesn't exist for this book.
+            # Should also account for upper range increased due to non standard chapters (skip over them)
+            if ref_found == None:
+                self.log.log_to_file(f"{ref} XML Not Found...", f"XML", "DEBUG")
+                return
+
+            # Have to add encapsulating tags, since otherwise only first chapter tag, 
+            #       will be included when parsed as xml, ignoring the rest of the text
+            ref_text = """<usx version="3.0">\n"""
+
+            if self.scope == "verse":
+                closing = ""
+                for node in start_tag.parents:
+                    closing += f"\n</{node.name}>"
+                    ref_text += f"{start_tag.parent}\n"
+                    if node.name == "para" or node.name == "table":
+                        break
+                    else: 
+                        ref_text += start_tag.parent 
+
+                ref_text += ref_found.group(0)
+
+                ref_text += closing
+
+            else:
+                ref_text += ref_found.group(0)
+            ref_text += "\n</usx>"
+        else: 
+            ref_text = book_xml
+
+        if ref_text != None:
+            self.details["xml"] = ref_text
 
     def get_strongs(self, scope):
         params = []
@@ -685,7 +743,6 @@ class Assembler:
                     FROM bible.verseoccurences
                     WHERE id = %s
                 """, (verse_id,))
-                print(start_node, end_node)
                 base_query += " AND id BETWEEN %s AND %s"
                 params.extend([start_node, end_node])
 
@@ -704,9 +761,11 @@ class Assembler:
         pass
     
     def get_cross_refs(self):
+        # All cross reference in and out
         pass
     
     def get_foot_notes(self):
+        # Only for this translation
         pass
     
     def get_user_notes(self):

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -241,7 +241,7 @@ class Assembler:
             self.manager.get_obj().set_default_bucket("bible-dbl-raw")
 
         self.db = self.manager.get_db()
-        self.log = self.manager.create_log("assembler")
+        self.log = self.manager.create_log_in_folder("assembler", ["logs", "assembler"])
         self.log.set_logging_level(2)
 
         self.nodes  = [] # Represents all (tokenisable) nodes used to reconstruct context

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -184,6 +184,39 @@ class Assembler:
             WHERE n.is_tokenisable = TRUE
             ORDER BY n.id;
         """,
+        "get_matched_verse_ref": """
+            WITH input_ref AS (
+                SELECT %s AS ref
+            ),
+
+            -- 1. Check if canonical verse exists e.g. GEN 3:1
+            direct_match AS (
+                SELECT vo.verse_ref
+                FROM bible.verseoccurences vo
+                JOIN input_ref i ON vo.verse_ref = i.ref
+                WHERE vo.translation_id = %s
+            ),
+
+            -- 2. If not, find non-standard refs that map *to* the input canonical ref e.g. if exists GEN 3:1-2
+            fallback_match AS (
+                SELECT vc.non_standard_verse_ref AS verse_ref
+                FROM bible.verse_correction vc
+                JOIN bible.verseoccurences vo 
+                    ON vo.verse_ref = vc.non_standard_verse_ref
+                JOIN input_ref i ON vc.verse_ref = i.ref
+                WHERE vo.translation_id = %s
+            )
+
+            -- 3. Prefer direct match; if none, return fallback
+            SELECT verse_ref
+            FROM direct_match
+
+            UNION ALL
+
+            SELECT verse_ref
+            FROM fallback_match
+            LIMIT 1;  -- return first match only              
+        """,
         # NOT IN USE YET
         "get_ref_all_verseoccurences": """
             SELECT * 
@@ -630,17 +663,13 @@ class Assembler:
                 self.details["full_ref"] += " " + chapter_ref.split(" ")[1]
                 
             case "verse":
-                verse_ref = ref
-                # Check if visible for translation, if not
-
-                # check verse corrections for alternative
-
-                # if still nothing then return null
+                verse_ref = self.db.fetch_clean_one(self.SQL.get("get_matched_verse_ref"), (ref, translation_id, translation_id))
 
                 valid_nodes = self.db.fetch_all(
                     self.SQL.get("get_verse_from_ref"), 
-                    (ref, translation_id)
+                    (verse_ref, translation_id)
                 )
+
                 sample_node = valid_nodes[0]
 
                 book_map_id         = sample_node[2]

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -760,40 +760,20 @@ class Assembler:
 
     def get_strongs(self, scope):
         params = []
-        
-        base_query = self.SQL.get("get_strongs_in_range")
 
-        match scope:
-            case "book":
-                book_map_id = self.details.get("book")
-                base_query += " AND book_map_id = %s"
-                params.append(book_map_id)
+        soup = BeautifulSoup(self.get_details("xml"), "xml")
 
-            case "chapter":
-                chapter_id = self.details.get("chapter")
-                start_node, end_node = self.db.fetch_one("""
-                    SELECT start_node, end_node
-                    FROM bible.chapteroccurences
-                    WHERE id = %s
-                """, (chapter_id,))
-                base_query += " AND id BETWEEN %s AND %s"
-                params.extend([start_node, end_node])
+        # Get all nodes with a 'strong' attribute
+        nodes = soup.find_all(attrs={"strong": True})
 
-            case "verse":
-                verse_id = self.details.get("verse")
-                print(verse_id)
-                start_node, end_node = self.db.fetch_one("""
-                    SELECT start_node, end_node
-                    FROM bible.verseoccurences
-                    WHERE id = %s
-                """, (verse_id,))
-                base_query += " AND id BETWEEN %s AND %s"
-                params.extend([start_node, end_node])
+        # Extract their strong values
+        strong_values = [node.get("strong") for node in nodes]
 
-        found_strongs = self.db.fetch_all_single(base_query, params)
+        # Make them unique
+        unique_strongs = set(strong_values)
 
-        if len(found_strongs) > 0:
-            self.details["strongs"] = found_strongs
+        if len(unique_strongs) > 0:
+            self.details["strongs"] = list(unique_strongs)
     
     def get_entities(self):
         pass
@@ -817,7 +797,7 @@ class Assembler:
 
 # Used for TESTING
 if __name__ == "__main__":
-    test_translation = 7
+    test_translation = 8
     test_occurence = 1
     test_node_id = 22
     test_node_path = "/usx:0/para:13/verse:1"

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -631,6 +631,12 @@ class Assembler:
                 
             case "verse":
                 verse_ref = ref
+                # Check if visible for translation, if not
+
+                # check verse corrections for alternative
+
+                # if still nothing then return null
+
                 valid_nodes = self.db.fetch_all(
                     self.SQL.get("get_verse_from_ref"), 
                     (ref, translation_id)

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -12,6 +12,10 @@ import traceback
 
 from manager.managerhandler import ManagerHandler
 
+VERSE   = "verse"
+CHAPTER = "chapter"
+BOOK    = "book"
+
 class Assembler:
     SQL = {
         # Reconstruct from OCCURENCE -> ID
@@ -216,9 +220,13 @@ class Assembler:
             SET reconstructed_text = %s
             WHERE id = %s;
         """,
+        # Base Classes that are extended
         "get_strongs_in_range": """
-
-        """
+            SELECT DISTINCT strong
+            FROM bible.nodes
+            WHERE strong IS NOT NULL
+        """,
+        # Helper Classes
     }
 
     def __init__(
@@ -331,6 +339,8 @@ class Assembler:
         self.details["scope"]   = self.scope
         self.details["text"]    = self.text
         self.details["nodes"]   = self.nodes
+
+        self.get_strongs(self.scope)
         
         # Log the resulted reconstruction - if it was successful (no error flagged)
         self.log.log_to_file(f"Reconstruction: [\n{self.text}\n]", "OCCURENCE", "DEBUG")
@@ -646,8 +656,43 @@ class Assembler:
     def set_xml(self):
         pass
 
-    def get_strongs(self):
-        pass
+    def get_strongs(self, scope):
+        params = []
+        
+        base_query = self.SQL.get("get_strongs_in_range")
+
+        match scope:
+            case "book":
+                book_map_id = self.details.get("book")
+                base_query += " AND book_map_id = %s"
+                params.append(book_map_id)
+
+            case "chapter":
+                chapter_id = self.details.get("chapter")
+                start_node, end_node = self.db.fetch_one("""
+                    SELECT start_node, end_node
+                    FROM bible.chapteroccurences
+                    WHERE id = %s
+                """, (chapter_id,))
+                base_query += " AND id BETWEEN %s AND %s"
+                params.extend([start_node, end_node])
+
+            case "verse":
+                verse_id = self.details.get("verse")
+                print(verse_id)
+                start_node, end_node = self.db.fetch_one("""
+                    SELECT start_node, end_node
+                    FROM bible.verseoccurences
+                    WHERE id = %s
+                """, (verse_id,))
+                print(start_node, end_node)
+                base_query += " AND id BETWEEN %s AND %s"
+                params.extend([start_node, end_node])
+
+        found_strongs = self.db.fetch_all_single(base_query, params)
+
+        if len(found_strongs) > 0:
+            self.details["strongs"] = found_strongs
     
     def get_entities(self):
         pass
@@ -669,7 +714,7 @@ class Assembler:
 
 # Used for TESTING
 if __name__ == "__main__":
-    test_translation = 1
+    test_translation = 7
     test_occurence = 1
     test_node_id = 22
     test_node_path = "/usx:0/para:13/verse:1"
@@ -679,18 +724,18 @@ if __name__ == "__main__":
 
     # ======= OCCURENCE =======
     # REQUIRED: scope, occurence_id
-    temp = Assembler(scope=test_scope, occurence_id=test_occurence) # GEN
-    print(temp.get_details())
+    # temp = Assembler(scope=test_scope, occurence_id=test_occurence) # GEN
+    # print(temp.get_details())
 
-    # ======= NODE ID =======
-    # REQUIRED: scope, node_id
-    temp = Assembler(scope=test_scope, node_id=test_node_id) # GEN
-    print(temp.get_details())
+    # # ======= NODE ID =======
+    # # REQUIRED: scope, node_id
+    # temp = Assembler(scope=test_scope, node_id=test_node_id) # GEN
+    # print(temp.get_details())
 
-    # ======= NODE PATH =======
-    # REQUIRED: scope, canonical_path, translation_id
-    temp = Assembler(scope=test_scope, canonical_path=test_node_path, translation_id=test_translation)
-    print(temp.get_details())
+    # # ======= NODE PATH =======
+    # # REQUIRED: scope, canonical_path, translation_id
+    # temp = Assembler(scope=test_scope, canonical_path=test_node_path, translation_id=test_translation)
+    # print(temp.get_details())
 
     # ======= REF =======
     # REQUIRED: ref, translation_id

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -785,7 +785,7 @@ if __name__ == "__main__":
     test_occurence = 1
     test_node_id = 22
     test_node_path = "/usx:0/para:13/verse:1"
-    test_scope = "verse"
+    test_scope = "chapter"
     # test_scope = "chapter"
     # test_scope = "verse"
 
@@ -819,4 +819,6 @@ if __name__ == "__main__":
             test_ref = f"{test_book} {test_chapter}:{test_verse}"
 
     temp = Assembler(ref=test_ref, translation_id=test_translation)
+    print(temp.get_details())
+    temp.add_detail()
     print(temp.get_details())

--- a/services/tokeniser/tokenisation.py
+++ b/services/tokeniser/tokenisation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import os
 
 from manager.managerhandler import ManagerHandler
+from tokeniser.assembler import Assembler
 
 # Decided I need to better tokenise so first will load all verses and then update the data for them later, I want tokens afterall in my database.
 
@@ -116,7 +117,7 @@ class Tokenisation:
 
         self.log.log_to_file(f"Linked to Language with ID: {self.language_id}", "INIT", "INFO")
 
-        self.reconstruct_chapter_nodes()
+        self.reconstruct_translation_chapters()
 
         self.log.log_to_file(f"Finished Constructing Tokens: {self.language_id}", "INIT", "INFO")
 
@@ -131,7 +132,7 @@ class Tokenisation:
         self.db.commit()
         self.db.close()
     
-    def reconstruct_chapter_nodes(self):
+    def reconstruct_translation_chapters(self):
         # Get all Books for this Translation
         all_books = self.db.fetch_all(self.SQL.get("get_translation_books"), (self.translation_id,))
 
@@ -140,25 +141,10 @@ class Tokenisation:
             all_chapters = self.db.fetch_all(self.SQL.get("get_book_chapters"), (book_map_id,))
 
             for chapter_occurence_id,_,chapter_ref in all_chapters:
-                # Get all tokenisable nodes for this chapter.
-                tokenisable_nodes = self.db.fetch_all(self.SQL.get("get_chapter_tokenisable_nodes"), (chapter_occurence_id,))
-                self.log.log_to_file(f"Nodes found to be tokenisable for [{chapter_ref}]: [{tokenisable_nodes}]", "NODE", "DEBUG")
-
-                chapter_text = ""
-
-                for node_id, text in tokenisable_nodes:
-                    start = len(chapter_text)
-                    chapter_text+=text  # Accumulate text for chapter occurence from nodes
-                    end = len(chapter_text)
-
-                    # Update start, end offsets for node
-                    self.db.execute(self.SQL.get("update_node_offsets"), (start, end, node_id))
-
-                # When finished iterating through nodes
-                #       update chapter_occurences with reconstructed chapter_text
-                self.db.execute(self.SQL.get("update_chapter_occurence_text"), (chapter_text, chapter_occurence_id))
-                # print(chapter_text)
-                self.log.log_to_file(f"Reconstructed Chapter [{chapter_ref}] Occurence [{chapter_occurence_id}]: \n[{chapter_text}\n]", "NODE", "TRACE")
+                # Reconstruct for chapter
+                assembled_chapter = Assembler(scope="chapter", occurence_id=chapter_occurence_id, is_nlp=True)
+                
+                self.log.log_to_file(f"Reconstructed Chapter [{chapter_ref}] using Assembler : [{assembled_chapter.get_details()}]", "NODE", "DEBUG")
     
     def create_tokens(self):
         # Init spacy pipeline used for training

--- a/services/tokeniser/tokenisation.py
+++ b/services/tokeniser/tokenisation.py
@@ -62,73 +62,6 @@ class Tokenisation:
             INSERT INTO lookup.nlp_tag_types (tag) VALUES %s ON CONFLICT DO NOTHING;
         """,
         # --------------------------------- Node Types ---------------------------------
-        "init_tokenisable_nodes": """
-            WITH RECURSIVE text_nodes AS (
-                SELECT
-                    n.id          AS text_node_id,
-                    n.parent_node_id
-                FROM bible.nodes n
-                WHERE n.node_type = 'text'
-                AND n.canonical_path LIKE '%%para%%text%%'
-                AND n.canonical_path NOT LIKE '%%note%%'
-                AND n.book_map_id IN (
-                    SELECT id
-                    FROM bible.booktofile
-                    WHERE translation_id = %s
-                )
-            ),
-            ancestor_chain AS (
-                -- seed: start at the text node's parent
-                SELECT
-                    t.text_node_id,
-                    t.parent_node_id      AS ancestor_id,
-                    1                     AS depth
-                FROM text_nodes t
-
-                UNION ALL
-
-                -- step: move one level up each time
-                SELECT
-                    ac.text_node_id,
-                    n.parent_node_id      AS ancestor_id,
-                    ac.depth + 1          AS depth
-                FROM ancestor_chain ac
-                JOIN bible.nodes n
-                ON n.id = ac.ancestor_id
-                WHERE ac.ancestor_id IS NOT NULL
-            ),
-            para_for_text AS (
-                SELECT DISTINCT ON (ac.text_node_id)
-                    ac.text_node_id,
-                    ac.ancestor_id AS para_node_id,
-                    ac.depth
-                FROM ancestor_chain ac
-                JOIN bible.nodes p
-                ON p.id = ac.ancestor_id
-                WHERE p.node_type = 'para'
-                ORDER BY ac.text_node_id, ac.depth  -- keep nearest para
-            )
-            UPDATE bible.nodes n
-            SET is_tokenisable = TRUE
-            FROM para_for_text pt
-            JOIN bible.paragraphs bp
-            ON bp.node_id = pt.para_node_id
-            WHERE n.id = pt.text_node_id
-            AND bp.is_versetext = TRUE
-            AND n.is_tokenisable IS DISTINCT FROM TRUE;
-        """,
-        "get_tokenisable_nodes": """
-            SELECT
-                n.id AS text_node_id,
-                n.node_text
-            FROM bible.nodes n
-            WHERE n.is_tokenisable = 'true'
-            AND n.book_map_id IN (
-                    SELECT id FROM bible.booktofile
-                    WHERE translation_id = %s   -- <-- your target translation
-            )
-            ORDER BY n.id ASC
-        """,
         "get_chapter_tokenisable_nodes": """
             WITH chapter_bounds AS (
                 SELECT start_node, end_node
@@ -182,10 +115,6 @@ class Tokenisation:
         self.language_id = self.db.fetch_clean_one(self.SQL.get("get_language"), (self.translation_id,))
 
         self.log.log_to_file(f"Linked to Language with ID: {self.language_id}", "INIT", "INFO")
-
-        self.db.execute(self.SQL.get("init_tokenisable_nodes"), (self.translation_id,))
-
-        self.log.log_to_file(f"Initialised Tokenisable Nodes!", "INIT", "INFO")
 
         self.reconstruct_chapter_nodes()
 

--- a/services/tokeniser/tokenisation.py
+++ b/services/tokeniser/tokenisation.py
@@ -1,12 +1,5 @@
 import spacy
 
-from psycopg2.extras import execute_values
-import time
-import datetime
-import sys
-from pathlib import Path
-import os
-
 from manager.managerhandler import ManagerHandler
 from tokeniser.assembler import Assembler
 

--- a/services/tokeniser/tokenisation.py
+++ b/services/tokeniser/tokenisation.py
@@ -112,7 +112,7 @@ class Tokenisation:
 
         self.reconstruct_translation_chapters()
 
-        self.log.log_to_file(f"Finished Constructing Tokens: {self.language_id}", "INIT", "INFO")
+        self.log.log_to_file(f"COMPLETED Translation Re Construction!", "INIT", "INFO")
 
         self.create_tokens()
 

--- a/services/tokeniser/tokenisation.py
+++ b/services/tokeniser/tokenisation.py
@@ -101,7 +101,7 @@ class Tokenisation:
 
         self.db = self.manager.get_db()
         self.obj = self.manager.get_obj()
-        self.log = self.manager.create_log(f"_TOKENS-{self.translation_id}")
+        self.log = self.manager.create_log_in_folder(f"TOKENS-{self.translation_id}", ["logs", "tokenisation"])
         self.log.set_logging_level(1)
 
         self.log.log_to_file(f"Starting Tokenisation ...\n", "TOKENISATION", "INFO")

--- a/services/utilities/search.py
+++ b/services/utilities/search.py
@@ -56,22 +56,35 @@ class Search():
         "get_strong_nodes": """
             SELECT id
             FROM bible.nodes
-            WHERE strong LIKE %s
-                AND translation_id = %s
+            WHERE strong = %s
         """,
         "get_unique_strong_text": """
             WITH strongs_nodes AS (
                 SELECT id
                 FROM bible.nodes
-                WHERE strong LIKE %s
-                AND translation_id = %s
+                WHERE strong = %s
             )
             SELECT DISTINCT n.node_text
             FROM bible.nodes n
             JOIN strongs_nodes sn
             ON n.parent_node_id = sn.id
             WHERE n.node_text IS NOT NULL
-  AND n.node_text <> '';
+            AND n.node_text <> '';
+        """,
+        "get_strongs_occurences_per_translation" : """
+            SELECT 
+                sn.strong,
+                LOWER(n.node_text) AS node_text,
+                n.translation_id,
+                COUNT(*) AS occurrences
+            FROM bible.nodes sn
+            JOIN bible.nodes n
+                ON n.parent_node_id = sn.id
+            WHERE sn.strong IS NOT NULL
+            AND n.node_text IS NOT NULL
+            AND n.node_text <> ''
+            GROUP BY sn.strong, LOWER(n.node_text), n.translation_id
+            ORDER BY sn.strong, occurrences DESC;
         """
     }
 
@@ -169,14 +182,14 @@ class Search():
 
     def search_strongs(self, strong):
         # Find strongs occurences
-        nodes_found = self.db.fetch_all(self.SQL.get("get_word_nodes"), (f"{strong}", self.translation_id))
+        nodes_found = self.db.fetch_all(self.SQL.get("get_strong_nodes"), (strong,))
 
         # Find all unique words that use this strong code
-        unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (f"{strong}", self.translation_id))
+        unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (strong,))
         for word in unique_words:
             print(word)
 
-        results = self.search_results(nodes_found)
+        results = self.search_results(nodes_found, config=["full_ref", "translation", "text"])
 
         self.create_csv_file(f"{strong}", results["csv"])
 
@@ -211,3 +224,6 @@ class Search():
 if __name__ == "__main__":
     new_search = Search()
     new_search.search_word("fruit")
+
+    again_search = Search()
+    again_search.search_strongs("H7397")

--- a/services/utilities/search.py
+++ b/services/utilities/search.py
@@ -80,7 +80,7 @@ class Search():
         self.manager.get_obj().set_default_bucket("bible-dbl-raw")
 
         self.db = self.manager.get_db()
-        self.log = self.manager.create_log("search")
+        self.log = self.manager.create_log_in_folder("search", ["logs", "search"])
         self.log.set_logging_level(2)
 
         self.translation_id     = 1
@@ -196,7 +196,7 @@ class Search():
         pass
 
     def create_csv_file(self, file_name, contents):
-        file_folder = Path(__file__).parents[2] / "logs" / "csv"
+        file_folder = Path(__file__).parents[2] / "logs" / "search" / "csv"
         file_path = file_folder / f"{file_name}.tsv"
 
         try:


### PR DESCRIPTION
Refactor aimed at optimising the way we initialise tokenisable nodes, originally kept separate from ingestion pipeline. So here we implement it as part of normal Ingestion pipeline so Tokenisation can happen more smoothly and faster.

We also then continue to reflect these changes across the rest of the code base to reflect this, while also making some minor quality of life changes.

Additionally made changes to Ingestor to allow you to cutomise what Translations it loads in. As well as to Assembler, to accept rendering of xml to return for assembled object together with strongs numbers if available for assembled object.