### PR TITLE
feature: Strongs Concordance Data Ingestion

### DIFF
--- a/services/database/server/schemas/v1_schema.sql
+++ b/services/database/server/schemas/v1_schema.sql
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS bible.language_letters (
     FOREIGN KEY (parent_letter) REFERENCES bible.language_letters (id),
     FOREIGN KEY (ancient_symbol) REFERENCES bible.files (id),
     FOREIGN KEY (language_id) REFERENCES bible.languages (id)
-)
+);
 
 -- ================================================== Strongs Components ==================================================
 
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS bible.lexeme_relations (
     FOREIGN KEY (from_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
     FOREIGN KEY (to_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
     UNIQUE (from_lexeme, to_lexeme, relation_type)
-)
+);
 
 -- ================================================== Translation ==================================================
 

--- a/services/database/server/schemas/v1_schema.sql
+++ b/services/database/server/schemas/v1_schema.sql
@@ -323,7 +323,7 @@ CREATE TABLE IF NOT EXISTS bible.nodes (
     FOREIGN KEY (book_map_id) REFERENCES bible.booktofile (id) ON DELETE CASCADE,
     FOREIGN KEY (translation_id) REFERENCES bible.translations (id) ON DELETE CASCADE,
     FOREIGN KEY (node_type) REFERENCES lookup.node_types (node) ON DELETE CASCADE,
-    FOREIGN KEY (strong) REFERENCES bible.strongs (code) ON DELETE SET NULL
+    FOREIGN KEY (strong) REFERENCES bible.lexemes (strongs_code) ON DELETE CASCADE
 );
 CREATE INDEX idx_bible_nodes_node_text ON bible.nodes (node_text) WHERE is_tokenisable = TRUE;
 CREATE INDEX idx_bible_nodes_sid ON bible.nodes (sid) WHERE sid IS NOT NULL;

--- a/services/database/server/schemas/v1_schema.sql
+++ b/services/database/server/schemas/v1_schema.sql
@@ -205,14 +205,45 @@ CREATE TABLE IF NOT EXISTS bible.bookgroupnames (
 
 -- ================================================== Strongs Components ==================================================
 
-CREATE TABLE IF NOT EXISTS bible.strongs (
+CREATE TABLE IF NOT EXISTS bible.lexemes (
     id              SERIAL PRIMARY KEY,
-    code            TEXT UNIQUE,
+    source          TEXT,   -- 'strongs', 'bdb', 'manual'
+    source_version  TEXT,
+    strongs_code    TEXT UNIQUE, 
+    -- EXAMPLES of different sources:
+    -- BDB          (Brown–Driver–Briggs)
+    -- HALOT        (Hebrew and Aramaic Lexicon of the Old Testament))
+    -- TDOT         (Theological Dictionary of the Old Testament)
+    -- BDAG         (A Greek–English Lexicon of the New Testament and Other Early Christian Literature)
+    -- LSJ          (Liddell–Scott–Jones)
+    -- TDNT         (The Theological Dictionary of the New Testament)
+    -- Louw-Nida    (The Louw–Nida Greek-English Lexicon of the New Testament Based on Semantic Domains)
+    -- Manual       (I can add some lexemes manually?)
+    -- Wiktionary
+    -- NLP? -> through tokens table
     language_id     INTEGER,
-	-- Consider either storing bible.strongs Definition or api call to get it?
-    FOREIGN KEY (language_id) REFERENCES bible.languages (id) ON DELETE CASCADE
+    lemma           TEXT,
+    raw_pos         TEXT,
+    transliteration TEXT,
+    pronunciation   TEXT,
+    audio_file      INTEGER, -- Pronounciation audio file link
+    raw_gloss       TEXT,
+    FOREIGN KEY (language_id) REFERENCES bible.languages (id) ON DELETE CASCADE,
+    FOREIGN KEY (audio_file) REFERENCES bible.files (id)
 );
-CREATE INDEX idx_bible_strongs_code ON bible.strongs (code);
+CREATE INDEX idx_bible_lexemes_strongs_code ON bible.lexemes (strongs_code) WHERE strongs_code IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS bible.lexeme_relations (
+    id              SERIAL PRIMARY KEY,
+    from_lexeme     INTEGER,
+    to_lexeme       INTEGER,
+    relation_type   TEXT,
+    confidence      TEXT, -- Scholarly honesty? Don't need to use yet
+    notes           TEXT,
+    FOREIGN KEY (from_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
+    FOREIGN KEY (to_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
+    UNIQUE (from_lexeme, to_lexeme, relation_type)
+)
 
 -- ================================================== bible.chapters ==================================================
 

--- a/services/database/server/schemas/v1_schema.sql
+++ b/services/database/server/schemas/v1_schema.sql
@@ -108,6 +108,7 @@ CREATE TABLE IF NOT EXISTS bible.lexemes (
     -- Wiktionary
     -- NLP? -> through tokens table
     language_id     INTEGER,
+    native_word     TEXT,
     lemma           TEXT,
     raw_pos         TEXT,
     transliteration TEXT,

--- a/services/database/server/schemas/v1_schema.sql
+++ b/services/database/server/schemas/v1_schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS bible.properties (
     FOREIGN KEY (style_id) REFERENCES bible.styles (id) ON DELETE CASCADE
 );
 
--- ================================================== Translation ==================================================
+-- ================================================== Languages ==================================================
 
 CREATE TABLE IF NOT EXISTS bible.languages (
     id                  SERIAL PRIMARY KEY,
@@ -75,6 +75,63 @@ CREATE TABLE IF NOT EXISTS bible.languages (
     scriptDirection     TEXT
 );
 CREATE INDEX idx_bible_languages_iso ON bible.languages (iso);
+
+CREATE TABLE IF NOT EXISTS bible.language_letters (
+    id              SERIAL PRIMARY KEY,
+    letter          TEXT,  
+    phoneme         TEXT, -- Whether 'vowel' or 'consonant'
+    parent_letter   INTEGER,
+    ancient_symbol  INTEGER,
+    symbol_def      TEXT,
+    language_id     INTEGER,
+    FOREIGN KEY (parent_letter) REFERENCES bible.language_letters (id),
+    FOREIGN KEY (ancient_symbol) REFERENCES bible.files (id),
+    FOREIGN KEY (language_id) REFERENCES bible.languages (id)
+)
+
+-- ================================================== Strongs Components ==================================================
+
+CREATE TABLE IF NOT EXISTS bible.lexemes (
+    id              SERIAL PRIMARY KEY,
+    source          TEXT,   -- 'strongs', 'bdb', 'manual'
+    source_version  TEXT,
+    strongs_code    TEXT UNIQUE, 
+    -- EXAMPLES of different sources:
+    -- BDB          (Brown–Driver–Briggs)
+    -- HALOT        (Hebrew and Aramaic Lexicon of the Old Testament))
+    -- TDOT         (Theological Dictionary of the Old Testament)
+    -- BDAG         (A Greek–English Lexicon of the New Testament and Other Early Christian Literature)
+    -- LSJ          (Liddell–Scott–Jones)
+    -- TDNT         (The Theological Dictionary of the New Testament)
+    -- Louw-Nida    (The Louw–Nida Greek-English Lexicon of the New Testament Based on Semantic Domains)
+    -- Manual       (I can add some lexemes manually?)
+    -- Wiktionary
+    -- NLP? -> through tokens table
+    language_id     INTEGER,
+    lemma           TEXT,
+    raw_pos         TEXT,
+    transliteration TEXT,
+    pronunciation   TEXT,
+    audio_file      INTEGER, -- Pronounciation audio file link
+    raw_gloss       TEXT,
+    FOREIGN KEY (language_id) REFERENCES bible.languages (id) ON DELETE CASCADE,
+    FOREIGN KEY (audio_file) REFERENCES bible.files (id)
+);
+CREATE INDEX idx_bible_lexemes_strongs_code ON bible.lexemes (strongs_code) WHERE strongs_code IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS bible.lexeme_relations (
+    id              SERIAL PRIMARY KEY,
+    from_lexeme     INTEGER,
+    to_lexeme       INTEGER,
+    relation_type   TEXT,
+    confidence      TEXT, -- Scholarly honesty? Don't need to use yet
+    notes           TEXT,
+    FOREIGN KEY (from_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
+    FOREIGN KEY (to_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
+    UNIQUE (from_lexeme, to_lexeme, relation_type)
+)
+
+-- ================================================== Translation ==================================================
 
 CREATE TABLE IF NOT EXISTS bible.dblinfo (
     dbl_id                  TEXT,
@@ -202,48 +259,6 @@ CREATE TABLE IF NOT EXISTS bible.bookgroupnames (
     FOREIGN KEY (book_group_id) REFERENCES bible.bookgroups (id) ON DELETE CASCADE,
     FOREIGN KEY (language_id) REFERENCES bible.languages (id) ON DELETE CASCADE
 );
-
--- ================================================== Strongs Components ==================================================
-
-CREATE TABLE IF NOT EXISTS bible.lexemes (
-    id              SERIAL PRIMARY KEY,
-    source          TEXT,   -- 'strongs', 'bdb', 'manual'
-    source_version  TEXT,
-    strongs_code    TEXT UNIQUE, 
-    -- EXAMPLES of different sources:
-    -- BDB          (Brown–Driver–Briggs)
-    -- HALOT        (Hebrew and Aramaic Lexicon of the Old Testament))
-    -- TDOT         (Theological Dictionary of the Old Testament)
-    -- BDAG         (A Greek–English Lexicon of the New Testament and Other Early Christian Literature)
-    -- LSJ          (Liddell–Scott–Jones)
-    -- TDNT         (The Theological Dictionary of the New Testament)
-    -- Louw-Nida    (The Louw–Nida Greek-English Lexicon of the New Testament Based on Semantic Domains)
-    -- Manual       (I can add some lexemes manually?)
-    -- Wiktionary
-    -- NLP? -> through tokens table
-    language_id     INTEGER,
-    lemma           TEXT,
-    raw_pos         TEXT,
-    transliteration TEXT,
-    pronunciation   TEXT,
-    audio_file      INTEGER, -- Pronounciation audio file link
-    raw_gloss       TEXT,
-    FOREIGN KEY (language_id) REFERENCES bible.languages (id) ON DELETE CASCADE,
-    FOREIGN KEY (audio_file) REFERENCES bible.files (id)
-);
-CREATE INDEX idx_bible_lexemes_strongs_code ON bible.lexemes (strongs_code) WHERE strongs_code IS NOT NULL;
-
-CREATE TABLE IF NOT EXISTS bible.lexeme_relations (
-    id              SERIAL PRIMARY KEY,
-    from_lexeme     INTEGER,
-    to_lexeme       INTEGER,
-    relation_type   TEXT,
-    confidence      TEXT, -- Scholarly honesty? Don't need to use yet
-    notes           TEXT,
-    FOREIGN KEY (from_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
-    FOREIGN KEY (to_lexeme) REFERENCES bible.lexemes (id) ON DELETE CASCADE,
-    UNIQUE (from_lexeme, to_lexeme, relation_type)
-)
 
 -- ================================================== bible.chapters ==================================================
 

--- a/services/ingestor/nodes.py
+++ b/services/ingestor/nodes.py
@@ -86,10 +86,6 @@ class Nodes:
                 this_node[12] = node.get("loc") # loc, 12
                 this_node[17] = node.get("align") # align, 17 
 
-                # Consider creating init for all strongs numbers instead
-                if strong != None:
-                    self.createStrongs(strong)
-
             if isinstance(node, NavigableString):  
                 node_type = "text"
 
@@ -191,30 +187,6 @@ class Nodes:
         nodes = self.created_nodes["note"]
         self.log.log_to_file(f"Requested Note Nodes: {nodes}", f"NODE", "DEBUG")
         return nodes
-    
-    # May remove if I choose to initialise it in a different way e.g. init script
-    def createStrongs(self, strong_code):
-        # Write any new unique strongs that haven't been added to database yet
-        strong_id = self.db.fetch_one("""
-            SELECT id FROM bible.strongs WHERE code=%s
-        """, (strong_code,))
-
-        if strong_id == None:
-            # check what language the code belongs to 
-            language_id = None
-            if strong_code[0:1] == "G": # Greek
-                language_id = self.db.fetch_clean_one("""
-                    SELECT id FROM bible.languages WHERE name LIKE 'Greek%'
-                """)
-            elif strong_code[0:1] == "H": # Hebrew
-                language_id = self.db.fetch_clean_one("""
-                    SELECT id FROM bible.languages WHERE name LIKE 'Hebrew%'
-                """)
-
-            self.db.execute("""
-                INSERT INTO bible.strongs (code, language_id) 
-                VALUES (%s, %s)
-            """, (strong_code, language_id))
 
 # if __name__ == "__main__":
 #     test_book_xml = None

--- a/services/ingestor/strongs.py
+++ b/services/ingestor/strongs.py
@@ -1,6 +1,6 @@
 import requests
 from pathlib import Path
-import csv
+import pandas
 
 SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?rlkey=puni8uqrdgcbikq1fkqg52576&e=1"
 
@@ -10,6 +10,8 @@ class Strongs:
         self.strongs_csv_path = Path(__file__).parents[2] / "downloads" / "strongs.xlsx"
         if not self.strongs_csv_path.exists():
             self.download_strongs_csv()
+
+        self.pre_process_xlsx()
 
     def download_strongs_csv(self):
         # In the future considering checking differences, and downloading based on that? if source requires
@@ -25,6 +27,18 @@ class Strongs:
                         f.write(chunk)
 
         print("Downloaded CSV file")
+
+    def pre_process_xlsx(self):
+        pass
+        xls = pandas.ExcelFile(self.strongs_csv_path)
+        print(xls.sheet_names) # Allows for reading .xlsx files
+        # Sheets of interst: ['Hebrew', 'Greek', 'letters', 'BibleBook Numbers']
+        # Next Steps
+        # Remove specific mentions of english word occurence from Gloss (our system will handle that for translations that support this)
+
+        # No need to do occurences
+
+        # A need to see letter occurence
 
 if __name__ == "__main__":
     Strongs()

--- a/services/ingestor/strongs.py
+++ b/services/ingestor/strongs.py
@@ -4,18 +4,20 @@ import csv
 
 SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?rlkey=puni8uqrdgcbikq1fkqg52576&e=1"
 
+# Depening on the source I use, the way I preprocess the data for my project will change
 class Strongs:
     def __init__(self):
-        self.strongs_csv_path = self.download_strongs_csv()
+        self.strongs_csv_path = Path(__file__).parents[2] / "archive" / "strongs.xlsx"
+        if not self.strongs_csv_path.exists():
+            self.download_strongs_csv()
 
     def download_strongs_csv(self):
+        # In the future considering checking differences, and downloading based on that? if source requires
         url = "https://www.dropbox.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?dl=1"
-        strongs_csv = Path(__file__).parents[2] / "archive"
 
-        strongs_csv.parent.mkdir(parents=True, exist_ok=True)
+        self.strongs_csv_path.parent.mkdir(parents=True, exist_ok=True)
 
         r = requests.get(url, timeout=60)
         r.raise_for_status()
 
-        strongs_csv.write_bytes(r.content)
-        return strongs_csv
+        self.strongs_csv_path.write_bytes(r.content)

--- a/services/ingestor/strongs.py
+++ b/services/ingestor/strongs.py
@@ -1,0 +1,21 @@
+import requests
+from pathlib import Path
+import csv
+
+SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?rlkey=puni8uqrdgcbikq1fkqg52576&e=1"
+
+class Strongs:
+    def __init__(self):
+        self.strongs_csv_path = self.download_strongs_csv()
+
+    def download_strongs_csv(self):
+        url = "https://www.dropbox.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?dl=1"
+        strongs_csv = Path(__file__).parents[2] / "archive"
+
+        strongs_csv.parent.mkdir(parents=True, exist_ok=True)
+
+        r = requests.get(url, timeout=60)
+        r.raise_for_status()
+
+        strongs_csv.write_bytes(r.content)
+        return strongs_csv

--- a/services/ingestor/strongs.py
+++ b/services/ingestor/strongs.py
@@ -7,17 +7,24 @@ SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Str
 # Depening on the source I use, the way I preprocess the data for my project will change
 class Strongs:
     def __init__(self):
-        self.strongs_csv_path = Path(__file__).parents[2] / "archive" / "strongs.xlsx"
+        self.strongs_csv_path = Path(__file__).parents[2] / "downloads" / "strongs.xlsx"
         if not self.strongs_csv_path.exists():
             self.download_strongs_csv()
 
     def download_strongs_csv(self):
         # In the future considering checking differences, and downloading based on that? if source requires
-        url = "https://www.dropbox.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?dl=1"
+        url = SOURCE_URL
 
         self.strongs_csv_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        with requests.get(url, stream=True, allow_redirects=True, timeout=60) as r:
+            r.raise_for_status()
+            with open(self.strongs_csv_path, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
 
-        r = requests.get(url, timeout=60)
-        r.raise_for_status()
+        print("Downloaded CSV file")
 
-        self.strongs_csv_path.write_bytes(r.content)
+if __name__ == "__main__":
+    Strongs()

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -11,10 +11,10 @@ SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Str
 class StrongsIngestor:
     SQL = {
         "create_strongs": """
-            INSERT INTO bible.lexemes (source, strongs_code, language_id, lemma, raw_pos, transliteration, pronunciation, raw_gloss) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO bible.lexemes (source, strongs_code, language_id, lemma, raw_pos, transliteration, pronunciation, raw_gloss) VALUES %s
         """,
         "create_strongs_relation": """
-            INSERT INTO bible.lexeme_relations (from_lexeme, to_lexeme, relation_type, confidence, notes) VALUES (%s, %s, %s, %s, %s)
+            INSERT INTO bible.lexeme_relations (from_lexeme, to_lexeme, relation_type) VALUES %s
         """,
     }
     def __init__(self, manager: ManagerHandler):
@@ -28,13 +28,15 @@ class StrongsIngestor:
             self.download_strongs_csv()
 
         self.lexeme_mapping = {}
+        self.lexeme_relation_mapping = {}
         self.strongs_data = []
         self.strongs_relations = []
         self.lexeme_id = 1
 
         self.pre_process_xlsx()
         self.process_hebrew_sheet()
-        self.process_greek_sheet()
+        # self.process_greek_sheet()
+
         self.bulk_export_strongs()
 
     def download_strongs_csv(self):
@@ -84,11 +86,11 @@ class StrongsIngestor:
         print(sheet.columns)
         return sheet
 
-    def extract_strongs(self, sheet, language_id):
+    def extract_strongs(self, sheet, language_id, language):
         for row in sheet.itertuples(index=False):
             this_lexeme = [None] * 8
             this_lexeme[0] = "strongs"
-            strongs_code = f"G{row.number}"
+            strongs_code = f"{language}{row.number}"
             this_lexeme[1] = strongs_code
             this_lexeme[2] = language_id
 
@@ -101,8 +103,8 @@ class StrongsIngestor:
 
             if type(row.gloss) == str:
                 for i, line in enumerate(row.gloss.splitlines()):
+                    temp_relations = []
                     if i == 0:  
-                        print(line)
                         split_bracket = line.split("(")
 
                         if len(split_bracket) < 2:
@@ -115,8 +117,24 @@ class StrongsIngestor:
                         this_lexeme[6] = pronunciation
                         
                         raw_gloss += f"{line}\n"
-                    elif not line.startswith("KJV") and not line.startswith("Root"):
+
+                    elif not line.startswith("KJV") and not line.startswith("Root") and not line.startswith("Compare"):
                         raw_gloss += f"{line}\n"
+
+                    elif line.startswith("Root(s): "):
+                        all_roots_raw = line[8:].split(",")
+                        for root in all_roots_raw:
+                            temp_relations.append((root.strip(), "root"))
+                            
+                    elif line.startswith("Compare: "):
+                        all_compares_raw = line[8:].split(",")
+                        for compare in all_compares_raw:
+                            compare_str = compare.strip()
+                            if (compare_str.startswith("H") or compare_str.startswith("G")) and compare_str[1:].isdigit():
+                                temp_relations.append((compare_str, "compare"))
+                    
+                    if len(temp_relations) > 0:
+                        self.lexeme_relation_mapping[self.lexeme_id] = temp_relations
             
             this_lexeme[7] = raw_gloss
             self.strongs_data.append(tuple(this_lexeme))
@@ -135,7 +153,7 @@ class StrongsIngestor:
         language_id = self.db.fetch_clean_one("""
             SELECT id FROM bible.languages WHERE name LIKE 'Hebrew%'
         """)
-        self.extract_strongs(sheet, language_id)
+        self.extract_strongs(sheet, language_id, "H")
 
     def process_greek_sheet(self):
         sheet = self.get_sheet(
@@ -147,11 +165,19 @@ class StrongsIngestor:
         language_id = self.db.fetch_clean_one("""
             SELECT id FROM bible.languages WHERE name LIKE 'Greek%'
         """)
-        self.extract_strongs(sheet, language_id)
+        self.extract_strongs(sheet, language_id, "G")
 
     def bulk_export_strongs(self):
-        print(self.strongs_data)
+        # self.strongs_data
         # self.db.bulk_insert(self.SQL.get("create_strongs"), self.strongs_data)
+        print(self.lexeme_mapping)
+
+        for from_lexeme_id, to_strongs_relations in self.lexeme_relation_mapping.items():
+            for to_strong, relation_type in to_strongs_relations:
+                to_lexeme_id = self.lexeme_mapping[to_strong]
+                self.strongs_relations.append((from_lexeme_id, to_lexeme_id, relation_type))
+
+        print(self.strongs_relations)
         # self.db.bulk_insert(self.SQL.get("create_strongs_relation"), self.strongs_relations)
 
 if __name__ == "__main__":

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -12,6 +12,8 @@ class StrongsIngestor:
             self.download_strongs_csv()
 
         self.pre_process_xlsx()
+        self.process_hebrew_sheet()
+        self.process_greek_sheet()
 
     def download_strongs_csv(self):
         # In the future considering checking differences, and downloading based on that? if source requires
@@ -39,6 +41,24 @@ class StrongsIngestor:
         # No need to do occurences
 
         # A need to see letter occurence
+
+    def process_hebrew_sheet(self):
+        sheet = pandas.read_excel(
+            self.strongs_csv_path,
+            sheet_name="Hebrew",
+            engine="openpyxl"
+        )
+        print(sheet.columns)
+        pass
+
+    def process_greek_sheet(self):
+        sheet = pandas.read_excel(
+            self.strongs_csv_path,
+            sheet_name="Greek",
+            engine="openpyxl"
+        )
+        print(sheet.columns)
+        pass
 
 if __name__ == "__main__":
     StrongsIngestor()

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -56,7 +56,7 @@ class StrongsIngestor:
 
     def pre_process_xlsx(self):
         xls = pandas.ExcelFile(self.strongs_csv_path)
-        print(xls.sheet_names) # Allows for reading .xlsx files
+        # print(xls.sheet_names) # Allows for reading .xlsx files
 
     def get_sheet(self, sheet_name: str, columns:list):
         sheet = pandas.read_excel(
@@ -75,7 +75,7 @@ class StrongsIngestor:
             .str.replace(".", "_")
             .str.replace("#", "number")
         )
-        print(sheet.columns)
+        # print(sheet.columns)
         return sheet
 
     def extract_strongs(self, sheet, language_id, language):
@@ -182,7 +182,7 @@ class StrongsIngestor:
 
                 # Remove duplicates
                 if new_relation in self.strongs_relations:
-                    print(f"=======> {new_relation}")
+                    self.log.log_to_file(f"Entry is Duplicate: {new_relation}", "STRONGS_INGESTOR", "WARN")
                     continue
 
                 self.strongs_relations.append(new_relation)

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -11,7 +11,7 @@ SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Str
 class StrongsIngestor:
     SQL = {
         "create_strongs": """
-            INSERT INTO bible.lexemes (source, strongs_code, language_id, lemma, raw_pos, transliteration, pronunciation, raw_gloss) VALUES %s
+            INSERT INTO bible.lexemes (source, strongs_code, language_id, lemma, raw_pos, transliteration, pronunciation, raw_gloss, native_word) VALUES %s
         """,
         "create_strongs_relation": """
             INSERT INTO bible.lexeme_relations (from_lexeme, to_lexeme, relation_type) VALUES %s
@@ -80,7 +80,7 @@ class StrongsIngestor:
 
     def extract_strongs(self, sheet, language_id, language):
         for row in sheet.itertuples(index=False):
-            this_lexeme = [None] * 8
+            this_lexeme = [None] * 9
             this_lexeme[0] = "strongs"
             strongs_code = f"{language}{row.number}"
             this_lexeme[1] = strongs_code
@@ -131,6 +131,7 @@ class StrongsIngestor:
                         self.lexeme_relation_mapping[self.lexeme_id] = temp_relations
             
             this_lexeme[7] = raw_gloss
+            this_lexeme[8] = row.word
             self.strongs_data.append(tuple(this_lexeme))
             self.lexeme_mapping[strongs_code] = self.lexeme_id
             # print(row.word)

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -5,9 +5,18 @@ import pandas
 from manager.managerhandler import ManagerHandler
 
 SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?rlkey=puni8uqrdgcbikq1fkqg52576&e=1"
+# See: https://www.ancient-hebrew.org/ahlb/aleph.html
 
 # Depening on the source I use, the way I preprocess the data for my project will change
 class StrongsIngestor:
+    SQL = {
+        "create_strongs": """
+            INSERT INTO bible.lexemes (source, strongs_code, language_id, lemma, raw_pos, transliteration, pronunciation, raw_gloss) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        "create_strongs_relation": """
+            INSERT INTO bible.lexeme_relations (from_lexeme, to_lexeme, relation_type, confidence, notes) VALUES (%s, %s, %s, %s, %s)
+        """,
+    }
     def __init__(self, manager: ManagerHandler):
         self.manager = manager
         self.log = manager.create_log_in_folder()
@@ -18,9 +27,15 @@ class StrongsIngestor:
         if not self.strongs_csv_path.exists():
             self.download_strongs_csv()
 
+        self.lexeme_mapping = {}
+        self.strongs_data = []
+        self.strongs_relations = []
+        self.lexeme_id = 1
+
         self.pre_process_xlsx()
         self.process_hebrew_sheet()
         self.process_greek_sheet()
+        self.bulk_export_strongs()
 
     def download_strongs_csv(self):
         # In the future considering checking differences, and downloading based on that? if source requires
@@ -69,6 +84,38 @@ class StrongsIngestor:
         print(sheet.columns)
         return sheet
 
+    def extract_strongs(self, sheet, language_id):
+        for row in sheet.itertuples(index=False):
+            this_lexeme = [None] * 8
+            this_lexeme[0] = "strongs"
+            strongs_code = f"G{row.number}"
+            this_lexeme[1] = strongs_code
+            this_lexeme[2] = language_id
+
+            if row.root != "":
+                this_lexeme[3] = row.root
+
+            this_lexeme[4] = row.part_of_speech
+
+            raw_gloss = ""
+
+            for i, line in enumerate(row.gloss.splitlines()):
+                if i == 0:  
+                    split_bracket = line.split("(")
+                    transliteration = split_bracket[0].strip()
+                    this_lexeme[5] = transliteration
+
+                    pronunciation = split_bracket[1].split(")")[0]
+                    this_lexeme[6] = pronunciation
+                elif not line.startswith("KJV") and not line.startswith("Root"):
+                    raw_gloss += f"{line}\n"
+            
+            this_lexeme[7] = raw_gloss
+            self.strongs_data.append(tuple(this_lexeme))
+            self.lexeme_mapping[strongs_code] = self.lexeme_id
+            # print(row.word)
+            self.lexeme_id+=1 # Increment every row
+
     def process_hebrew_sheet(self):
         sheet = self.get_sheet(
             "Hebrew",
@@ -80,32 +127,23 @@ class StrongsIngestor:
         language_id = self.db.fetch_clean_one("""
             SELECT id FROM bible.languages WHERE name LIKE 'Hebrew%'
         """)
-        for row in sheet.itertuples(index=False):
-            strongs_code = f"H{row.number}"
-            print(strongs_code)
+        self.extract_strongs(sheet, language_id)
 
     def process_greek_sheet(self):
         sheet = self.get_sheet(
             "Greek",
             ['#', 'Word', 'Gloss', 'Root',
-            'Occ in other words', 'prep1', 'prep2', 'R1', 'R1-Gk', 'R2', 'R2-Gk',
+            'prep1', 'prep2', 'R1', 'R1-Gk', 'R2', 'R2-Gk',
             'R3', 'R3-Gk', 'Part of Speech', 'cl.Heb.eqt.']
         )
         language_id = self.db.fetch_clean_one("""
             SELECT id FROM bible.languages WHERE name LIKE 'Greek%'
         """)
-        for row in sheet.itertuples(index=False):
-            # print(row.word)
-            pass
-        pass
+        self.extract_strongs(sheet, language_id)
 
-    def create_strongs(self):
-        # Write New Strongs entry to the database
-        pass
-
-    def create_strongs_relation(self):
-        # Write New Strongs Relation to the database e.g. from Root strongs etc.
-        pass
+    def bulk_export_strongs(self):
+        self.db.bulk_insert(self.SQL.get("create_strongs"), self.strongs_data)
+        # self.db.bulk_insert(self.SQL.get("create_strongs_relation"), self.strongs_relations)
 
 if __name__ == "__main__":
     StrongsIngestor()

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -42,22 +42,44 @@ class StrongsIngestor:
 
         # A need to see letter occurence
 
-    def process_hebrew_sheet(self):
+    def get_sheet(self, sheet_name: str, columns:list):
         sheet = pandas.read_excel(
             self.strongs_csv_path,
-            sheet_name="Hebrew",
-            engine="openpyxl"
+            sheet_name=sheet_name,
+            engine="openpyxl",
+            usecols=columns,
+            dtype=str
+        )
+        # Clean Up column names
+        sheet.columns = (
+            sheet.columns
+            .str.strip()
+            .str.lower()
+            .str.replace(" ", "_")
+            .str.replace(".", "_")
         )
         print(sheet.columns)
+        return sheet
+
+    def process_hebrew_sheet(self):
+        sheet = self.get_sheet(
+            "Hebrew",
+            ['#', 'Word', 'Gloss', 'Root', 'Pic Root',
+            '1st Root Strongs', '1st Root Hebrew', '2nd Root Strongs',
+            '2nd Root Hebrew2', '3rd Root Strongs', '3rd Root Hebrew',
+            'Part of Speech', 'cl.Gk.eqt.']
+        )
         pass
 
     def process_greek_sheet(self):
-        sheet = pandas.read_excel(
-            self.strongs_csv_path,
-            sheet_name="Greek",
-            engine="openpyxl"
+        sheet = self.get_sheet(
+            "Greek",
+            ['#', 'Word', 'Gloss', 'Root',
+            'Occ in other words', 'prep1', 'prep2', 'R1', 'R1-Gk', 'R2', 'R2-Gk',
+            'R3', 'R3-Gk', 'Part of Speech', 'cl.Heb.eqt.']
         )
-        print(sheet.columns)
+        for row in sheet.itertuples(index=False):
+            print(row.word)
         pass
 
 if __name__ == "__main__":

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -2,11 +2,18 @@ import requests
 from pathlib import Path
 import pandas
 
+from manager.managerhandler import ManagerHandler
+
 SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?rlkey=puni8uqrdgcbikq1fkqg52576&e=1"
 
 # Depening on the source I use, the way I preprocess the data for my project will change
 class StrongsIngestor:
-    def __init__(self):
+    def __init__(self, manager: ManagerHandler):
+        self.manager = manager
+        self.log = manager.create_log_in_folder()
+        self.db = manager.get_db()
+        self.obj = manager.get_obj()
+
         self.strongs_csv_path = Path(__file__).parents[2] / "downloads" / "strongs.xlsx"
         if not self.strongs_csv_path.exists():
             self.download_strongs_csv()
@@ -70,6 +77,9 @@ class StrongsIngestor:
             '2nd Root Hebrew2', '3rd Root Strongs', '3rd Root Hebrew',
             'Part of Speech', 'cl.Gk.eqt.']
         )
+        language_id = self.db.fetch_clean_one("""
+            SELECT id FROM bible.languages WHERE name LIKE 'Hebrew%'
+        """)
         for row in sheet.itertuples(index=False):
             strongs_code = f"H{row.number}"
             print(strongs_code)
@@ -81,6 +91,9 @@ class StrongsIngestor:
             'Occ in other words', 'prep1', 'prep2', 'R1', 'R1-Gk', 'R2', 'R2-Gk',
             'R3', 'R3-Gk', 'Part of Speech', 'cl.Heb.eqt.']
         )
+        language_id = self.db.fetch_clean_one("""
+            SELECT id FROM bible.languages WHERE name LIKE 'Greek%'
+        """)
         for row in sheet.itertuples(index=False):
             # print(row.word)
             pass

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -5,7 +5,7 @@ import pandas
 SOURCE_URL = "https://dl.dropboxusercontent.com/scl/fi/pq1gsb2cf6n7hnp1l378d/Strongs-Numbers.xlsx?rlkey=puni8uqrdgcbikq1fkqg52576&e=1"
 
 # Depening on the source I use, the way I preprocess the data for my project will change
-class Strongs:
+class StrongsIngestor:
     def __init__(self):
         self.strongs_csv_path = Path(__file__).parents[2] / "downloads" / "strongs.xlsx"
         if not self.strongs_csv_path.exists():
@@ -41,4 +41,4 @@ class Strongs:
         # A need to see letter occurence
 
 if __name__ == "__main__":
-    Strongs()
+    StrongsIngestor()

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -57,6 +57,7 @@ class StrongsIngestor:
             .str.lower()
             .str.replace(" ", "_")
             .str.replace(".", "_")
+            .str.replace("#", "number")
         )
         print(sheet.columns)
         return sheet
@@ -69,7 +70,9 @@ class StrongsIngestor:
             '2nd Root Hebrew2', '3rd Root Strongs', '3rd Root Hebrew',
             'Part of Speech', 'cl.Gk.eqt.']
         )
-        pass
+        for row in sheet.itertuples(index=False):
+            strongs_code = f"H{row.number}"
+            print(strongs_code)
 
     def process_greek_sheet(self):
         sheet = self.get_sheet(
@@ -79,7 +82,16 @@ class StrongsIngestor:
             'R3', 'R3-Gk', 'Part of Speech', 'cl.Heb.eqt.']
         )
         for row in sheet.itertuples(index=False):
-            print(row.word)
+            # print(row.word)
+            pass
+        pass
+
+    def create_strongs(self):
+        # Write New Strongs entry to the database
+        pass
+
+    def create_strongs_relation(self):
+        # Write New Strongs Relation to the database e.g. from Root strongs etc.
         pass
 
 if __name__ == "__main__":

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -168,17 +168,14 @@ class StrongsIngestor:
         self.extract_strongs(sheet, language_id, "G")
 
     def bulk_export_strongs(self):
-        # self.strongs_data
-        # self.db.bulk_insert(self.SQL.get("create_strongs"), self.strongs_data)
-        print(self.lexeme_mapping)
+        self.db.bulk_insert(self.SQL.get("create_strongs"), self.strongs_data)
 
         for from_lexeme_id, to_strongs_relations in self.lexeme_relation_mapping.items():
             for to_strong, relation_type in to_strongs_relations:
                 to_lexeme_id = self.lexeme_mapping[to_strong]
                 self.strongs_relations.append((from_lexeme_id, to_lexeme_id, relation_type))
 
-        print(self.strongs_relations)
-        # self.db.bulk_insert(self.SQL.get("create_strongs_relation"), self.strongs_relations)
+        self.db.bulk_insert(self.SQL.get("create_strongs_relation"), self.strongs_relations)
 
 if __name__ == "__main__":
     StrongsIngestor(ManagerHandler())

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -35,7 +35,7 @@ class StrongsIngestor:
 
         self.pre_process_xlsx()
         self.process_hebrew_sheet()
-        # self.process_greek_sheet()
+        self.process_greek_sheet()
 
         self.bulk_export_strongs()
 
@@ -52,19 +52,11 @@ class StrongsIngestor:
                     if chunk:
                         f.write(chunk)
 
-        print("Downloaded CSV file")
+        self.log.log_to_file(f"Downloaded Strongs Concordance Data with XLSX file", "STRONGS_INGESTOR", "DEBUG")
 
     def pre_process_xlsx(self):
-        pass
         xls = pandas.ExcelFile(self.strongs_csv_path)
         print(xls.sheet_names) # Allows for reading .xlsx files
-        # Sheets of interst: ['Hebrew', 'Greek', 'letters', 'BibleBook Numbers']
-        # Next Steps
-        # Remove specific mentions of english word occurence from Gloss (our system will handle that for translations that support this)
-
-        # No need to do occurences
-
-        # A need to see letter occurence
 
     def get_sheet(self, sheet_name: str, columns:list):
         sheet = pandas.read_excel(
@@ -94,7 +86,7 @@ class StrongsIngestor:
             this_lexeme[1] = strongs_code
             this_lexeme[2] = language_id
 
-            if row.root != "":
+            if row.root != "" and row.root != "NaN":
                 this_lexeme[3] = row.root
 
             this_lexeme[4] = row.part_of_speech
@@ -124,12 +116,14 @@ class StrongsIngestor:
                     elif line.startswith("Root(s): "):
                         all_roots_raw = line[8:].split(",")
                         for root in all_roots_raw:
+                            if root.strip() == '': continue
                             temp_relations.append((root.strip(), "root"))
                             
                     elif line.startswith("Compare: "):
                         all_compares_raw = line[8:].split(",")
                         for compare in all_compares_raw:
                             compare_str = compare.strip()
+                            if compare_str == '': continue
                             if (compare_str.startswith("H") or compare_str.startswith("G")) and compare_str[1:].isdigit():
                                 temp_relations.append((compare_str, "compare"))
                     
@@ -169,13 +163,33 @@ class StrongsIngestor:
 
     def bulk_export_strongs(self):
         self.db.bulk_insert(self.SQL.get("create_strongs"), self.strongs_data)
+        self.db.commit()
 
         for from_lexeme_id, to_strongs_relations in self.lexeme_relation_mapping.items():
+            from_strongs = next((k for k, v in self.lexeme_mapping.items() if v == from_lexeme_id), None)
+
             for to_strong, relation_type in to_strongs_relations:
-                to_lexeme_id = self.lexeme_mapping[to_strong]
-                self.strongs_relations.append((from_lexeme_id, to_lexeme_id, relation_type))
+
+                to_lexeme_id = self.lexeme_mapping.get(to_strong)
+                if to_lexeme_id == None:
+                    self.log.log_to_file(f"{to_strong} doesn't exist", "STRONGS_INGESTOR", "WARN")
+                    continue
+
+                self.log.log_to_file(f"{from_strongs}:{from_lexeme_id} <= {relation_type} => {to_strong}:{to_lexeme_id}", "STRONGS_INGESTOR", "DEBUG")
+                
+                new_relation = (from_lexeme_id, to_lexeme_id, relation_type)
+
+                # Remove duplicates
+                if new_relation in self.strongs_relations:
+                    print(f"=======> {new_relation}")
+                    continue
+
+                self.strongs_relations.append(new_relation)
 
         self.db.bulk_insert(self.SQL.get("create_strongs_relation"), self.strongs_relations)
+        self.db.commit()
+
+        self.log.log_to_file(f"Completed Strongs Data Import", "STRONGS_INGESTOR", "DEBUG")
 
 if __name__ == "__main__":
     StrongsIngestor(ManagerHandler())

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -19,7 +19,7 @@ class StrongsIngestor:
     }
     def __init__(self, manager: ManagerHandler):
         self.manager = manager
-        self.log = manager.create_log_in_folder()
+        self.log = manager.create_log_in_folder(["logs", "strongsingestor"], "strongs")
         self.db = manager.get_db()
         self.obj = manager.get_obj()
 
@@ -99,16 +99,24 @@ class StrongsIngestor:
 
             raw_gloss = ""
 
-            for i, line in enumerate(row.gloss.splitlines()):
-                if i == 0:  
-                    split_bracket = line.split("(")
-                    transliteration = split_bracket[0].strip()
-                    this_lexeme[5] = transliteration
+            if type(row.gloss) == str:
+                for i, line in enumerate(row.gloss.splitlines()):
+                    if i == 0:  
+                        print(line)
+                        split_bracket = line.split("(")
 
-                    pronunciation = split_bracket[1].split(")")[0]
-                    this_lexeme[6] = pronunciation
-                elif not line.startswith("KJV") and not line.startswith("Root"):
-                    raw_gloss += f"{line}\n"
+                        if len(split_bracket) < 2:
+                            continue
+
+                        transliteration = split_bracket[0].strip()
+                        this_lexeme[5] = transliteration
+
+                        pronunciation = split_bracket[1].split(")")[0]
+                        this_lexeme[6] = pronunciation
+                        
+                        raw_gloss += f"{line}\n"
+                    elif not line.startswith("KJV") and not line.startswith("Root"):
+                        raw_gloss += f"{line}\n"
             
             this_lexeme[7] = raw_gloss
             self.strongs_data.append(tuple(this_lexeme))
@@ -142,8 +150,9 @@ class StrongsIngestor:
         self.extract_strongs(sheet, language_id)
 
     def bulk_export_strongs(self):
-        self.db.bulk_insert(self.SQL.get("create_strongs"), self.strongs_data)
+        print(self.strongs_data)
+        # self.db.bulk_insert(self.SQL.get("create_strongs"), self.strongs_data)
         # self.db.bulk_insert(self.SQL.get("create_strongs_relation"), self.strongs_relations)
 
 if __name__ == "__main__":
-    StrongsIngestor()
+    StrongsIngestor(ManagerHandler())

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -19,6 +19,7 @@ spacy
 ast
 dotenv
 json
+openpyxl
 
 # python -m spacy download en_core_web_sm
 

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -19,6 +19,7 @@ spacy
 ast
 dotenv
 json
+pandas
 openpyxl
 
 # python -m spacy download en_core_web_sm


### PR DESCRIPTION
# What?
Added the ability and capability for Strongs Data to be Ingested and Stored in my Bible Insight Database.

# Why?
To enrich my Bible Insight data and allow for connecting ideas accross languages, with Strongs Concordance.

# Notes:
- Logic can be extended to other frameworks in the future if need be
- Found that USX actually only records from H1000 and G1000 onwards, which means it isn't as holistic as I thought for measuring occurences.
- However it should still be possible to identify with the help of inital strongs data here to supplement it, by searching Hebrew and Greek Translations for occurences (might not be 100% accurate but will suffice for now)
- Made space for ability to store info about letters and their mappings, like consonants and vowels as well as eventual symbols for ancient greek and hebrew with meanings as well
- Made room to add audio file links to strongs concordance pronunciation.
- It's been left out of scope to include strongs word breakdown's since it requires an advanced understanding of linguistic structure of the Hebrew and Greek Languages, and the idea is to make this simple for user to use and consume, so will be deferred for future development for now