### PR TITLE
feature: Strongs Assembler

### DIFF
--- a/devops/docker/paperless-ngx/README.md
+++ b/devops/docker/paperless-ngx/README.md
@@ -1,0 +1,5 @@
+# Paperless-ngx
+
+Consider using this to perhaps access the same volume minio storage is written to for persistance as a way to view specific files? Althrough might have to look at better ways to do this
+
+guide: https://docs.paperless-ngx.com/setup/#docker

--- a/devops/docker/paperless-ngx/docker-compose.yml
+++ b/devops/docker/paperless-ngx/docker-compose.yml
@@ -1,0 +1,63 @@
+# Docker Compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# In addition to that, this Docker Compose file adds the following optional
+# configurations:
+#
+# - Instead of SQLite (default), PostgreSQL is used as the database server.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker compose pull'.
+# - Run 'docker compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+services:
+  broker:
+    image: docker.io/library/redis:8
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+  db:
+    image: docker.io/library/postgres:18
+    restart: unless-stopped
+    volumes:
+      - pgdata:/var/lib/postgresql
+    environment:
+      POSTGRES_DB: paperless
+      POSTGRES_USER: paperless
+      POSTGRES_PASSWORD: paperless
+  webserver:
+    image: ghcr.io/paperless-ngx/paperless-ngx:latest
+    restart: unless-stopped
+    depends_on:
+      - db
+      - broker
+    ports:
+      - "8000:8000"
+    volumes:
+      - data:/usr/src/paperless/data
+      - media:/usr/src/paperless/media
+      - ./export:/usr/src/paperless/export
+      - ./consume:/usr/src/paperless/consume
+    env_file: docker-compose.env
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_DBHOST: db
+volumes:
+  data:
+  media:
+  pgdata:
+  redisdata:

--- a/services/app.py
+++ b/services/app.py
@@ -81,10 +81,11 @@ def start_api_server():
     print(response.status_code, response.text)
 
 if __name__ == "__main__":
+    RESET = True
     try:
-        restart_docker("postgres", False)
-        restart_docker("minio", False)
-        restart_docker("label-studio", False)
+        restart_docker("postgres", RESET)
+        restart_docker("minio", RESET)
+        restart_docker("label-studio", RESET)
         # restart_docker("authentik")
         # restart_docker("memgraph")
         initialise_script("init_labelstudio.py", 60) # Label Studio has a long delay before operational

--- a/services/app.py
+++ b/services/app.py
@@ -5,7 +5,7 @@ import time
 import os
 import shutil
 
-def restart_docker(container):
+def restart_docker(container, clear:bool = True):
     base = Path(__file__).parent.parent
     scripts_dir = base / "devops/docker" / container
 
@@ -15,12 +15,13 @@ def restart_docker(container):
         cwd=scripts_dir
     )
 
-    # Delete any folders inside this containers folder
-    for root, dirs, files in os.walk(scripts_dir, topdown=False):
-        for d in dirs:
-            dir_path = os.path.join(root, d)
-            print(f"Deleting folder: {dir_path}")
-            shutil.rmtree(dir_path)  # removes the entire directory and its contents
+    if clear:
+        # Delete any folders inside this containers folder
+        for root, dirs, files in os.walk(scripts_dir, topdown=False):
+            for d in dirs:
+                dir_path = os.path.join(root, d)
+                print(f"Deleting folder: {dir_path}")
+                shutil.rmtree(dir_path)  # removes the entire directory and its contents
 
     # Restart Docker instance
     subprocess.run(
@@ -81,9 +82,9 @@ def start_api_server():
 
 if __name__ == "__main__":
     try:
-        restart_docker("postgres")
-        restart_docker("minio")
-        restart_docker("label-studio")
+        restart_docker("postgres", False)
+        restart_docker("minio", False)
+        restart_docker("label-studio", False)
         # restart_docker("authentik")
         # restart_docker("memgraph")
         initialise_script("init_labelstudio.py", 60) # Label Studio has a long delay before operational

--- a/services/ingestor/ingestor.py
+++ b/services/ingestor/ingestor.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 from ingestor.translation import Translation
+from ingestor.strongsingestor import StrongsIngestor
 from manager.managerhandler import ManagerHandler
 
 class Ingestor:
@@ -14,6 +15,8 @@ class Ingestor:
         if manager == None:
             self.manager = ManagerHandler()
             self.manager.get_obj().set_default_bucket("bible-dbl-raw")
+
+        StrongsIngestor(self.manager)
 
         self.dbl_id = dbl_id
         self.agreement_id = agreement_id
@@ -211,5 +214,5 @@ class Ingestor:
 
 if __name__ == "__main__":
     # Ingestor()
-    # Ingestor(dbl_id="7142879509583d59", agreement_id="240016")
-    Ingestor(dbl_id="65eec8e0b60e656b", agreement_id="246069")
+    Ingestor(dbl_id="7142879509583d59", agreement_id="240016")
+    # Ingestor(dbl_id="65eec8e0b60e656b", agreement_id="246069")

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -16,6 +16,9 @@ class StrongsIngestor:
         "create_strongs_relation": """
             INSERT INTO bible.lexeme_relations (from_lexeme, to_lexeme, relation_type) VALUES %s
         """,
+        "check_lexemes": """
+            SELECT id FROM bible.lexemes WHERE strongs_code IS NOT NULL LIMIT 1
+        """
     }
     def __init__(self, manager: ManagerHandler):
         self.manager = manager
@@ -23,6 +26,12 @@ class StrongsIngestor:
         self.db = manager.get_db()
         self.obj = manager.get_obj()
 
+        initalised = self.db.fetch_clean_one(self.SQL.get("check_lexemes"))
+        if initalised: # If query returns a value
+            self.log.log_to_file(f"Skipping Ingestion, Data already present!", "STRONGS_INGESTOR", "INFO")
+            return # It's already been loaded so skip Ingestion of Strongs
+
+        self.log.log_to_file(f"Starting Ingestion", "STRONGS_INGESTOR", "INFO")
         self.strongs_csv_path = Path(__file__).parents[2] / "downloads" / "strongs.xlsx"
         if not self.strongs_csv_path.exists():
             self.download_strongs_csv()

--- a/services/ingestor/strongsingestor.py
+++ b/services/ingestor/strongsingestor.py
@@ -95,7 +95,7 @@ class StrongsIngestor:
             this_lexeme[1] = strongs_code
             this_lexeme[2] = language_id
 
-            if row.root != "" and row.root != "NaN":
+            if str(row.root) != "" and str(row.root) != "NaN":
                 this_lexeme[3] = row.root
 
             this_lexeme[4] = row.part_of_speech
@@ -125,14 +125,15 @@ class StrongsIngestor:
                     elif line.startswith("Root(s): "):
                         all_roots_raw = line[8:].split(",")
                         for root in all_roots_raw:
-                            if root.strip() == '': continue
-                            temp_relations.append((root.strip(), "root"))
+                            root_str = root.strip()
+                            if root_str == '' or root_str == 'NaN': continue
+                            temp_relations.append((root_str, "root"))
                             
                     elif line.startswith("Compare: "):
                         all_compares_raw = line[8:].split(",")
                         for compare in all_compares_raw:
                             compare_str = compare.strip()
-                            if compare_str == '': continue
+                            if compare_str == '' or compare_str == 'NaN': continue
                             if (compare_str.startswith("H") or compare_str.startswith("G")) and compare_str[1:].isdigit():
                                 temp_relations.append((compare_str, "compare"))
                     

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -326,7 +326,7 @@ class Assembler:
         }
 
         try:
-            self.assemble()
+            self.__assemble()
         except Exception as e:
             self.log.log_to_file("No Tokenisable Nodes for assembly suspected!", "ASSEMBLER", "WARN")
 
@@ -371,7 +371,7 @@ class Assembler:
 
         return None
             
-    def set_full_reference(self, book_map_id, is_book=False):
+    def __set_full_reference(self, book_map_id, is_book=False):
         book_details    = self.db.fetch_one(self.SQL.get("get_book_details"), (book_map_id,))
         book_code       = book_details[0]
         book_name       = book_details[1]
@@ -381,20 +381,20 @@ class Assembler:
 
         self.details["full_ref"] = book_name
     
-    def assemble(self):
+    def __assemble(self):
         # Attempt to automatically determine what reconstruction method to use
         if self.scope != None:
             if self.occurence_id != None:
                 self.log.log_to_file("Assembling through Occurence", "ASSEMBLER", "INFO")
-                self.reconstruct_occurence(self.scope, self.occurence_id)
+                self.__reconstruct_occurence(self.scope, self.occurence_id)
                 self.assembler_type = "occurence"
             elif self.node_id != None:
                 self.log.log_to_file("Assembling from Node ID", "ASSEMBLER", "INFO")
-                self.reconstruct_from_node_id(self.scope, self.node_id)
+                self.__reconstruct_from_node_id(self.scope, self.node_id)
                 self.assembler_type = "node_id"
             elif self.canonical_path != None and self.translation_id != None:
                 self.log.log_to_file("Assembling through Node Canonical Path", "ASSEMBLER", "INFO")
-                self.reconstruct_from_node_path(self.scope, self.translation_id, self.canonical_path)
+                self.__reconstruct_from_node_path(self.scope, self.translation_id, self.canonical_path)
                 self.assembler_type = "canonical_path"
             else:
                 self.log.log_to_file("Assembling failed! Insufficient parameters provided for reconstruction. Scope Defined, but no occurence, node_id or canonical_path!", "ASSEMBLER", "ERROR")
@@ -402,7 +402,7 @@ class Assembler:
                 # raise ValueError("Insufficient parameters provided for reconstruction.")
         elif self.ref != None and self.translation_id != None:
             self.log.log_to_file("Assembling through Ref", "ASSEMBLER", "INFO")
-            self.reconstruct_from_ref(self.translation_id, self.ref)
+            self.__reconstruct_from_ref(self.translation_id, self.ref)
             self.assembler_type = "ref"
         else:
             self.log.log_to_file("Assembling failed! Insufficient parameters provided for reconstruction. No Scope or Ref Defined!", "ASSEMBLER", "ERROR")
@@ -426,7 +426,7 @@ class Assembler:
         # Log the resulted reconstruction - if it was successful (no error flagged)
         self.log.log_to_file(f"Reconstruction: [\n{self.text}\n]", "OCCURENCE", "DEBUG")
 
-    def assemble_text(self, source: str, tokenisable_nodes: list, update_offsets:bool = False):
+    def __assemble_text(self, source: str, tokenisable_nodes: list, update_offsets:bool = False):
         self.log.log_to_file(f"Tokens for Reconstruction: f{tokenisable_nodes}", source, "DEBUG")
 
         temp_offsets = []
@@ -449,7 +449,7 @@ class Assembler:
             if self.details.get("scope") == "chapter":
                 self.db.execute(self.SQL.get("update_chapter_occurence_text"), (self.text, self.details.get("chapter")))
     
-    def reconstruct_occurence(self, scope, occurence_id):
+    def __reconstruct_occurence(self, scope, occurence_id):
         valid_nodes = None
         match scope:
             case "book":
@@ -468,7 +468,7 @@ class Assembler:
 
                 self.details["book"]        = book_map_id
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                         
             case "chapter":
                 chapter_occurence_id = occurence_id
@@ -488,7 +488,7 @@ class Assembler:
                 self.details["book"]        = book_map_id
                 self.details["chapter"]     = chapter_occurence_id
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + chapter_ref.split(" ")[1]
 
             case "verse":
@@ -511,12 +511,12 @@ class Assembler:
                 self.details["chapter"]     = chapter_occurence_id
                 self.details["verse"]       = verse_occurence_id
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
         
-        self.assemble_text("OCCURENCE", valid_nodes, self.is_nlp)
+        self.__assemble_text("OCCURENCE", valid_nodes, self.is_nlp)
 
-    def reconstruct_from_node_id(self, scope, node_id):
+    def __reconstruct_from_node_id(self, scope, node_id):
         valid_nodes = None
         match scope:
             case "book":
@@ -536,7 +536,7 @@ class Assembler:
                 self.details["node"]        = node_id
                 self.details["node_path"]   = self.db.fetch_clean_one(self.SQL.get("get_canonical_path_for_node"), (node_id,))
 
-                self.set_full_reference(book_map_id, True)
+                self.__set_full_reference(book_map_id, True)
 
             case "chapter":
                 valid_nodes = self.db.fetch_all(
@@ -559,7 +559,7 @@ class Assembler:
                 self.details["node"]        = node_id
                 self.details["node_path"]   = self.db.fetch_clean_one(self.SQL.get("get_canonical_path_for_node"), (node_id,))
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + chapter_ref.split(" ")[1]
 
             case "verse":
@@ -585,12 +585,12 @@ class Assembler:
                 self.details["node"]        = node_id
                 self.details["node_path"]   = self.db.fetch_clean_one(self.SQL.get("get_canonical_path_for_node"), (node_id,))
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.assemble_text("NODE_ID", valid_nodes, self.is_nlp)
+        self.__assemble_text("NODE_ID", valid_nodes, self.is_nlp)
 
-    def reconstruct_from_node_path(self, scope, translation_id, canonical_path):
+    def __reconstruct_from_node_path(self, scope, translation_id, canonical_path):
         valid_nodes = None
         match scope:
             case "book":
@@ -610,7 +610,7 @@ class Assembler:
                 self.details["node"]        = self.db.fetch_clean_one(self.SQL.get("get_node_id_for_canonical_path"), (canonical_path, translation_id))
                 self.details["node_path"]   = canonical_path
 
-                self.set_full_reference(book_map_id, True)
+                self.__set_full_reference(book_map_id, True)
                 
             case "chapter":
                 valid_nodes = self.db.fetch_all(
@@ -632,7 +632,7 @@ class Assembler:
                 self.details["node"]        = self.db.fetch_clean_one(self.SQL.get("get_node_id_for_canonical_path"), (canonical_path, translation_id))
                 self.details["node_path"]   = canonical_path
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + chapter_ref.split(" ")[1]
 
             case "verse":
@@ -657,12 +657,12 @@ class Assembler:
                 self.details["node"]        = self.db.fetch_clean_one(self.SQL.get("get_node_id_for_canonical_path"), (canonical_path, translation_id))
                 self.details["node_path"]   = canonical_path
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.assemble_text("CANONICAL_PATH", valid_nodes, self.is_nlp)
+        self.__assemble_text("CANONICAL_PATH", valid_nodes, self.is_nlp)
 
-    def reconstruct_from_ref(self, translation_id, ref:str):
+    def __reconstruct_from_ref(self, translation_id, ref:str):
         # Find if GEN, GEN 1, GEN 1:1 => Based on that change query
         scope = None
         if len(ref.split(" ")) == 1: # No space so book
@@ -687,7 +687,7 @@ class Assembler:
                 self.details["translation"] = translation_id
                 self.details["book"]        = book_map_id
 
-                self.set_full_reference(book_map_id, True)
+                self.__set_full_reference(book_map_id, True)
 
             case "chapter":
                 chapter_ref = ref
@@ -706,7 +706,7 @@ class Assembler:
                 self.details["book"]        = book_map_id
                 self.details["chapter"]     = chapter_occurence_id
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + chapter_ref.split(" ")[1]
                 
             case "verse":
@@ -730,10 +730,10 @@ class Assembler:
                 self.details["chapter"]     = chapter_occurence_id
                 self.details["verse"]       = verse_occurence_id
 
-                self.set_full_reference(book_map_id)
+                self.__set_full_reference(book_map_id)
                 self.details["full_ref"] += " " + verse_ref.split(" ")[1]
 
-        self.assemble_text("REF", valid_nodes, self.is_nlp)
+        self.__assemble_text("REF", valid_nodes, self.is_nlp)
     
     def add_detail(self):
         if self.valid_object and self.details != {'type': 'UNKNOWN'}:
@@ -747,7 +747,7 @@ class Assembler:
             self.get_foot_notes()
             self.get_user_notes()
 
-    def get_file_id(self):
+    def __get_file_id(self):
         book_map_id = self.details["book"]
         file_id = self.db.fetch_clean_one("""
             SELECT file_id FROM bible.booktofile WHERE id = %s;
@@ -757,7 +757,7 @@ class Assembler:
 
     # Perhaps function to help build on nodes, to display strongs if available?
     def set_xml(self):
-        book_xml = BeautifulSoup(self.obj.stream_file_from_file_id(self.get_file_id()), "xml")
+        book_xml = BeautifulSoup(self.obj.stream_file_from_file_id(self.__get_file_id()), "xml")
 
         ref_text = None
 

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -335,7 +335,7 @@ class Assembler:
 
             self.details["type"] = "ERROR"
 
-        if self.details == {'type': 'UNKNOWN'} or self.details == {'type': 'INVALID'} or self.details == {'type': 'ERROR'}:
+        if self.details == {'type': 'INVALID'} or self.details == {'type': 'ERROR'}:
             self.valid_object = False
 
     def __eq__(self, other):
@@ -734,7 +734,7 @@ class Assembler:
         self.assemble_text("REF", valid_nodes, self.is_nlp)
     
     def add_detail(self):
-        if self.valid_object:
+        if self.valid_object and self.details != {'type': 'UNKNOWN'}:
             self.set_xml()
             self.get_strongs()
 

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -329,6 +329,18 @@ class Assembler:
 
             error_message = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
             self.log.log_to_file(error_message, "ASSEMBLER", "ERROR")
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, Assembler)
+            and self.get_details("ref") != None
+            and self.get_details("translation") != None
+            and self.get_details("ref") == other.get_details("ref")
+            and self.get_details("translation") == other.get_details("translation")
+        )
+
+    def __hash__(self):
+        return hash((self.get_details("ref"), self.get_details("translation").get("id")))
     
     def get_details(self, detail=None):
         if detail == None:
@@ -397,8 +409,6 @@ class Assembler:
         self.details["nodes"]   = self.nodes
 
         result = self.db.fetch_one(self.SQL.get("get_translation_name"), (self.details.get("translation"),))
-
-        print(result)
 
         self.details["translation"] = {
             "name": result[0],
@@ -740,7 +750,6 @@ class Assembler:
 
     # Perhaps function to help build on nodes, to display strongs if available?
     def set_xml(self):
-        print(self.get_file_id())
         book_xml = BeautifulSoup(self.obj.stream_file_from_file_id(self.get_file_id()), "xml")
 
         ref_text = None

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -300,9 +300,12 @@ class Assembler:
         self.text   = ""
 
         self.assembler_type = None
+
+        self.valid_object = True
         # Commented out details init, so that only return what is relevant (no empty details returned on request)
+        # ---> Kept type for better user feedback on Assembly failure
         self.details = {
-            # "type": None,               # What type of assembly
+            "type": "UNKNOWN",            # What type of assembly
             # "scope": None,              # Scope it tried to reconstruct BOOK, CHAPTER, VERSE
             # "nodes": None,              # Tokenisable Nodes used in reconstruction
             # "text": None,               # Reconstructed Text from Tokenisable Nodes
@@ -329,6 +332,11 @@ class Assembler:
 
             error_message = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
             self.log.log_to_file(error_message, "ASSEMBLER", "ERROR")
+
+            self.details["type"] = "ERROR"
+
+        if self.details == {'type': 'UNKNOWN'} or self.details == {'type': 'INVALID'} or self.details == {'type': 'ERROR'}:
+            self.valid_object = False
 
     def __eq__(self, other):
         return (
@@ -394,6 +402,7 @@ class Assembler:
                 self.assembler_type = "canonical_path"
             else:
                 self.log.log_to_file("Assembling failed! Insufficient parameters provided for reconstruction. Scope Defined, but no occurence, node_id or canonical_path!", "ASSEMBLER", "ERROR")
+                self.details["type"]    = "INVALID"
                 # raise ValueError("Insufficient parameters provided for reconstruction.")
         elif self.ref != None and self.translation_id != None:
             self.log.log_to_file("Assembling through Ref", "ASSEMBLER", "INFO")
@@ -401,9 +410,11 @@ class Assembler:
             self.assembler_type = "ref"
         else:
             self.log.log_to_file("Assembling failed! Insufficient parameters provided for reconstruction. No Scope or Ref Defined!", "ASSEMBLER", "ERROR")
+            self.details["type"]    = "INVALID"
             # raise ValueError("Insufficient parameters provided for reconstruction.")
 
-        self.details["type"]    = self.assembler_type
+        if self.details.get("type") == "UNKNOWN": # Check if something forced value early
+            self.details["type"]    = self.assembler_type
         self.details["scope"]   = self.scope
         self.details["text"]    = self.text
         self.details["nodes"]   = self.nodes
@@ -729,7 +740,7 @@ class Assembler:
         self.assemble_text("REF", valid_nodes, self.is_nlp)
     
     def add_detail(self):
-        if self.details != {}:
+        if self.valid_object:
             self.set_xml()
             self.get_strongs()
 
@@ -741,12 +752,13 @@ class Assembler:
             self.get_user_notes()
 
     def get_file_id(self):
-        book_map_id = self.details["book"]
-        file_id = self.db.fetch_clean_one("""
-            SELECT file_id FROM bible.booktofile WHERE id = %s;
-        """, (book_map_id,))
-        self.details["file"] = file_id
-        return file_id
+        if self.valid_object:
+            book_map_id = self.details["book"]
+            file_id = self.db.fetch_clean_one("""
+                SELECT file_id FROM bible.booktofile WHERE id = %s;
+            """, (book_map_id,))
+            self.details["file"] = file_id
+            return file_id
 
     # Perhaps function to help build on nodes, to display strongs if available?
     def set_xml(self):

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -350,9 +350,9 @@ class Assembler:
         local_book = local_chapter.split(" ")[0]
 
         if self.scope == "chapter":
-            return Assembler(ref=local_book, translation_id=self.details.get("translation"))
+            return Assembler(manager=self.manager, ref=local_book, translation_id=self.details.get("translation"))
         elif self.scope == "verse":
-            return Assembler(ref=local_chapter, translation_id=self.details.get("translation"))
+            return Assembler(manager=self.manager, ref=local_chapter, translation_id=self.details.get("translation"))
 
         return None
             
@@ -830,7 +830,7 @@ if __name__ == "__main__":
     test_occurence = 1
     test_node_id = 22
     test_node_path = "/usx:0/para:13/verse:1"
-    test_scope = "chapter"
+    test_scope = "verse"
     # test_scope = "chapter"
     # test_scope = "verse"
 
@@ -868,6 +868,6 @@ if __name__ == "__main__":
     temp = Assembler(ref=test_ref, translation_id=test_translation)
     
     print(temp.get_details())
-    print(temp.get_parent_context().get_details())
-    # temp.add_detail()
-    # print(temp.get_details())
+    # print(temp.get_parent_context().get_details())
+    temp.add_detail()
+    print(temp.get_details())

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -263,10 +263,9 @@ class Assembler:
         """,
         # Helper Classes
         "get_translation_name": """
-            SELECT ti.name, ti.abbreviationLocal
-            FROM bible.translations t
-            JOIN bible.translationinfo ti ON t.dbl_id = ti.dbl_id
-            WHERE t.id = %s
+            SELECT name, abbreviationLocal
+            FROM bible.translations
+            WHERE id = %s
         """,
     }
 

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -351,21 +351,23 @@ class Assembler:
         return hash((self.get_details("ref"), self.get_details("translation").get("id")))
     
     def get_details(self, detail=None):
-        return self.details.get(detail)
+        if detail:
+            return self.details.get(detail)
+        else:
+            return self.details
             
     def get_parent_context(self):
-        if self.valid_object:
-            cur_ref = self.details.get("ref")
-            if not cur_ref: return None # if we can't access ref from details, don't create parent
+        cur_ref = self.details.get("ref")
+        if not cur_ref: return None # if we can't access ref from details, don't create parent
 
-            local_verse = cur_ref.split("-")[0]
-            local_chapter = local_verse.split(":")[0]
-            local_book = local_chapter.split(" ")[0]
+        local_verse = cur_ref.split("-")[0]
+        local_chapter = local_verse.split(":")[0]
+        local_book = local_chapter.split(" ")[0]
 
-            if self.scope == "chapter":
-                return Assembler(manager=self.manager, ref=local_book, translation_id=self.details.get("translation"))
-            elif self.scope == "verse":
-                return Assembler(manager=self.manager, ref=local_chapter, translation_id=self.details.get("translation"))
+        if self.scope == "chapter":
+            return Assembler(manager=self.manager, ref=local_book, translation_id=self.details.get("translation"))
+        elif self.scope == "verse":
+            return Assembler(manager=self.manager, ref=local_chapter, translation_id=self.details.get("translation"))
 
         return None
             
@@ -746,13 +748,12 @@ class Assembler:
             self.get_user_notes()
 
     def get_file_id(self):
-        if self.valid_object:
-            book_map_id = self.details["book"]
-            file_id = self.db.fetch_clean_one("""
-                SELECT file_id FROM bible.booktofile WHERE id = %s;
-            """, (book_map_id,))
-            self.details["file"] = file_id
-            return file_id
+        book_map_id = self.details["book"]
+        file_id = self.db.fetch_clean_one("""
+            SELECT file_id FROM bible.booktofile WHERE id = %s;
+        """, (book_map_id,))
+        self.details["file"] = file_id
+        return file_id
 
     # Perhaps function to help build on nodes, to display strongs if available?
     def set_xml(self):

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -341,6 +341,21 @@ class Assembler:
             else:
                 return None
             
+    def get_parent_context(self):
+        cur_ref = self.details.get("ref")
+        if not cur_ref: return None # if we can't access ref from details, don't create parent
+
+        local_verse = cur_ref.split("-")[0]
+        local_chapter = local_verse.split(":")[0]
+        local_book = local_chapter.split(" ")[0]
+
+        if self.scope == "chapter":
+            return Assembler(ref=local_book, translation_id=self.details.get("translation"))
+        elif self.scope == "verse":
+            return Assembler(ref=local_chapter, translation_id=self.details.get("translation"))
+
+        return None
+            
     def set_full_reference(self, book_map_id, is_book=False):
         book_details    = self.db.fetch_one(self.SQL.get("get_book_details"), (book_map_id,))
         book_code       = book_details[0]
@@ -848,7 +863,11 @@ if __name__ == "__main__":
         case "verse":
             test_ref = f"{test_book} {test_chapter}:{test_verse}"
 
+    print(test_ref)
+
     temp = Assembler(ref=test_ref, translation_id=test_translation)
+    
     print(temp.get_details())
-    temp.add_detail()
-    print(temp.get_details())
+    print(temp.get_parent_context().get_details())
+    # temp.add_detail()
+    # print(temp.get_details())

--- a/services/tokeniser/assembler.py
+++ b/services/tokeniser/assembler.py
@@ -351,27 +351,21 @@ class Assembler:
         return hash((self.get_details("ref"), self.get_details("translation").get("id")))
     
     def get_details(self, detail=None):
-        if detail == None:
-            return self.details
-        else:
-            found_detail = self.details.get(detail)
-            if found_detail:
-                return found_detail
-            else:
-                return None
+        return self.details.get(detail)
             
     def get_parent_context(self):
-        cur_ref = self.details.get("ref")
-        if not cur_ref: return None # if we can't access ref from details, don't create parent
+        if self.valid_object:
+            cur_ref = self.details.get("ref")
+            if not cur_ref: return None # if we can't access ref from details, don't create parent
 
-        local_verse = cur_ref.split("-")[0]
-        local_chapter = local_verse.split(":")[0]
-        local_book = local_chapter.split(" ")[0]
+            local_verse = cur_ref.split("-")[0]
+            local_chapter = local_verse.split(":")[0]
+            local_book = local_chapter.split(" ")[0]
 
-        if self.scope == "chapter":
-            return Assembler(manager=self.manager, ref=local_book, translation_id=self.details.get("translation"))
-        elif self.scope == "verse":
-            return Assembler(manager=self.manager, ref=local_chapter, translation_id=self.details.get("translation"))
+            if self.scope == "chapter":
+                return Assembler(manager=self.manager, ref=local_book, translation_id=self.details.get("translation"))
+            elif self.scope == "verse":
+                return Assembler(manager=self.manager, ref=local_chapter, translation_id=self.details.get("translation"))
 
         return None
             

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -1,0 +1,16 @@
+from manager.managerhandler import ManagerHandler
+
+class Strongs():
+    def __init__(self, manager: ManagerHandler):
+        self.manager = manager
+        self.db = manager.get_db()
+        
+        self.details = {
+            #
+        }
+
+    def search_strongs():
+        pass
+
+if __name__ == "__main":
+    pass

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -1,5 +1,9 @@
 from manager.managerhandler import ManagerHandler
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from tokeniser.strongs import Strongs
+
 class Strongs():
     SQL = {
         "get_unique_strong_text": """
@@ -49,22 +53,67 @@ class Strongs():
         """
     }
 
-    def __init__(self, manager: ManagerHandler, strong, translation_id, recursive_limit:int=3, recursive_depth:int=0):
+    def __init__(self, manager: ManagerHandler, strong, translation_id, recursive_limit:int=3, recursive_depth:int=0, parent_object: "Strongs" = None):
         self.manager = manager
         self.db = manager.get_db()
+
+        self.parent_object = parent_object
 
         self.strong = strong
         self.translation_id = translation_id
         self.recursive_depth = recursive_depth
         self.recursive_limit = recursive_limit
         
-        self.details = {
-            
-        }
+        self.details = {}
+        self.all_objects = {}
 
         self.search_strongs()
         self.get_strong_data()
+
+        self.root = False
+        if recursive_depth == 0:
+            self.root = True
+            self.set_new_child_object(self.strong, self)
+        else:
+            self.get_root().set_new_child_object(self.strong, self)
+
+        self.connected_relations = {}
+        # Create local version for this object, where you link the object if its already been created.
+
         self.strongs_recursion()
+
+    def get_root(self):
+        strong_object = self
+        while not strong_object.is_root():
+            strong_object = strong_object.get_parent_object()
+
+        return strong_object
+    
+    def get_object_in_root(self, strongs_code):
+        if self.root:
+            return self.all_objects.get(strongs_code)
+        
+        return None
+
+    def get_parent_object(self):
+        return self.parent_object
+
+    def is_root(self):
+        return self.root
+    
+    def get_strong(self):
+        return self.strong
+    
+    def get_details(self):
+        return self.details
+    
+    def get_connected_relations(self):
+        return self.connected_relations
+    
+    def set_new_child_object(self, strongs_code:str, object:"Strongs"):
+        # Basically add all created child roots, but only if already exists
+        if self.root:
+            self.all_objects[strongs_code]
 
     def search_strongs(self):
         # Find all unique words that use this strong code
@@ -80,12 +129,16 @@ class Strongs():
         self.details["pos"] = info[7]
         self.details["gloss"] = info[11]
 
+        self.all_objects[self.strong] = self
+
     def strongs_recursion(self):
         lexeme_id = self.details["id"]
         relations = self.db.fetch_all(self.SQL.get("get_strongs_relation"), (self.strong,))
-        print(relations)
-        print("===========================")
+        # print(relations)
+        # print("===========================")
+
         all_relations = set()
+        
         for relation_type, from_id, from_strongs, from_lemma, to_id, to_strongs, to_lemma in relations:
             if from_strongs != self.strong:
                 all_relations.add(from_strongs)
@@ -93,10 +146,15 @@ class Strongs():
             if to_strongs != self.strong:
                 all_relations.add(to_strongs)
         
+        # Before creating a new object find out whether it's already been created in the recursive stack by someone else
         for relation in all_relations:
             new_depth = self.recursive_depth+1
             if new_depth <= self.recursive_limit:
-                Strongs(self.manager, relation, self.translation_id, self.recursive_limit, new_depth)
+                existing_object = self.get_root().get_object_in_root(relation)
+                if existing_object:
+                    self.connected_relations[relation] = existing_object
+                else:
+                    self.connected_relations[relation] = Strongs(self.manager, relation, self.translation_id, self.recursive_limit, new_depth)
 
 if __name__ == "__main__":
     Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -1,16 +1,40 @@
 from manager.managerhandler import ManagerHandler
 
 class Strongs():
-    def __init__(self, manager: ManagerHandler):
+    SQL = {
+        "get_unique_strong_text": """
+            WITH strongs_nodes AS (
+                SELECT id
+                FROM bible.nodes
+                WHERE strong = %s
+            )
+            SELECT DISTINCT n.node_text
+            FROM bible.nodes n
+            JOIN strongs_nodes sn
+            ON n.parent_node_id = sn.id
+            WHERE n.node_text IS NOT NULL
+            AND n.node_text <> '';
+        """,
+    }
+
+    def __init__(self, manager: ManagerHandler, strong, translation_id):
         self.manager = manager
         self.db = manager.get_db()
+
+        self.strong = strong
+        self.translation_id = translation_id
         
         self.details = {
             #
         }
 
-    def search_strongs():
-        pass
+        self.search_strongs()
+
+    def search_strongs(self):
+        # Find all unique words that use this strong code
+        unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (self.strong,))
+        for word in unique_words:
+            print(word)
 
 if __name__ == "__main":
-    pass
+    Strongs(ManagerHandler())

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -18,7 +18,8 @@ class Strongs():
             WHERE p.strong = %s
             AND p.translation_id = %s
             AND c.node_text IS NOT NULL
-            AND c.node_text <> '';
+            AND c.node_text <> ''
+            ORDER BY p.id ASC;
         """,
         "get_strong_data": """
             SELECT * FROM bible.lexemes WHERE strongs_code = %s
@@ -87,7 +88,7 @@ class Strongs():
     
     def get_occurences(self, key:str=None, display=False, count=False, unique=False):
         if not self.details.get("occurences"): return None
-        
+
         valid = True
         unique_counts = []
         for this_key in self.details["occurences"].keys():
@@ -116,7 +117,7 @@ class Strongs():
                     for assembled_verse in results:
                         full_ref = assembled_verse.get_details("full_ref")
                         text = assembled_verse.get_details("text")
-                        print(f"\n{full_ref} => [{text}]\n")
+                        print(f"\n{full_ref} => [{this_key}] => [{text}]\n")
 
         if count and unique:
             return 
@@ -131,9 +132,10 @@ class Strongs():
 
         for strong_node_id, text_node_id, strongs_text in all_occurences:
             if cleaned_occurences.get(strongs_text):
-                cleaned_occurences[strongs_text].append(Assembler(manager=self.manager, node_id=strong_node_id, scope="verse"))
+                cleaned_occurences[strongs_text].add(Assembler(manager=self.manager, node_id=strong_node_id, scope="verse"))
             else:
-                cleaned_occurences[strongs_text] = [Assembler(manager=self.manager, node_id=strong_node_id, scope="verse")]
+                cleaned_occurences[strongs_text] = set()
+                cleaned_occurences[strongs_text].add(Assembler(manager=self.manager, node_id=strong_node_id, scope="verse"))
         
         self.details["occurences"] = cleaned_occurences
 

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -21,22 +21,50 @@ class Strongs():
         """,
         "get_strong_data": """
             SELECT * FROM bible.lexemes WHERE strongs_code = %s
+        """,
+        "get_strongs_relation": """
+            WITH target_lexeme AS (
+                SELECT id
+                FROM bible.lexemes
+                WHERE strongs_code = %s
+            )
+            SELECT
+                lr.relation_type,
+                --lr.confidence,
+                --lr.notes,
+
+                l_from.id            AS from_id,
+                l_from.strongs_code  AS from_strongs,
+                l_from.lemma         AS from_lemma,
+
+                l_to.id              AS to_id,
+                l_to.strongs_code    AS to_strongs,
+                l_to.lemma           AS to_lemma
+            FROM bible.lexeme_relations lr
+            JOIN target_lexeme t
+            ON lr.from_lexeme = t.id
+            OR lr.to_lexeme   = t.id
+            JOIN bible.lexemes l_from ON l_from.id = lr.from_lexeme
+            JOIN bible.lexemes l_to   ON l_to.id   = lr.to_lexeme;
         """
     }
 
-    def __init__(self, manager: ManagerHandler, strong, translation_id):
+    def __init__(self, manager: ManagerHandler, strong, translation_id, recursive_limit:int=3, recursive_depth:int=0):
         self.manager = manager
         self.db = manager.get_db()
 
         self.strong = strong
         self.translation_id = translation_id
+        self.recursive_depth = recursive_depth
+        self.recursive_limit = recursive_limit
         
         self.details = {
-            #
+            
         }
 
         self.search_strongs()
         self.get_strong_data()
+        self.strongs_recursion()
 
     def search_strongs(self):
         # Find all unique words that use this strong code
@@ -45,8 +73,30 @@ class Strongs():
             print(word)
 
     def get_strong_data(self):
-        info = self.db.fetch_all(self.SQL.get("get_strong_data"), (self.strong,))
+        info = self.db.fetch_one(self.SQL.get("get_strong_data"), (self.strong,))
         print(info)
+        self.details["id"] = info[0] # Lexeme_id
+        self.details["code"] = self.strong
+        self.details["pos"] = info[7]
+        self.details["gloss"] = info[11]
+
+    def strongs_recursion(self):
+        lexeme_id = self.details["id"]
+        relations = self.db.fetch_all(self.SQL.get("get_strongs_relation"), (self.strong,))
+        print(relations)
+        print("===========================")
+        all_relations = set()
+        for relation_type, from_id, from_strongs, from_lemma, to_id, to_strongs, to_lemma in relations:
+            if from_strongs != self.strong:
+                all_relations.add(from_strongs)
+            
+            if to_strongs != self.strong:
+                all_relations.add(to_strongs)
+        
+        for relation in all_relations:
+            new_depth = self.recursive_depth+1
+            if new_depth <= self.recursive_limit:
+                Strongs(self.manager, relation, self.translation_id, self.recursive_limit, new_depth)
 
 if __name__ == "__main__":
     Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -1,5 +1,6 @@
 from manager.managerhandler import ManagerHandler
 
+from tokeniser.assembler import Assembler
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from tokeniser.strongs import Strongs
@@ -7,21 +8,17 @@ if TYPE_CHECKING:
 class Strongs():
     SQL = {
         "get_unique_strong_text": """
-            WITH strongs_nodes AS (
-                SELECT id
-                FROM bible.nodes
-                WHERE strong = %s AND translation_id = %s
-            )
             SELECT
-                n.node_text,
-                COUNT(*) AS occurrence_count
-            FROM bible.nodes n
-            JOIN strongs_nodes sn
-            ON n.parent_node_id = sn.id
-            WHERE n.node_text IS NOT NULL
-            AND n.node_text <> ''
-            GROUP BY n.node_text
-            ORDER BY occurrence_count DESC;
+                p.id        AS strong_node_id,
+                c.id        AS text_node_id,
+                c.node_text AS text
+            FROM bible.nodes p
+            JOIN bible.nodes c
+                ON c.parent_node_id = p.id
+            WHERE p.strong = %s
+            AND p.translation_id = %s
+            AND c.node_text IS NOT NULL
+            AND c.node_text <> '';
         """,
         "get_strong_data": """
             SELECT * FROM bible.lexemes WHERE strongs_code = %s
@@ -90,10 +87,17 @@ class Strongs():
     
     def search_strongs(self):
         # Find all unique words that use this strong code
-        unique_words = self.db.fetch_all_single(self.SQL.get("get_unique_strong_text"), (self.strong, self.translation_id))
-        self.details["occurences"] = unique_words
-        for word in unique_words:
-            print(word)
+        all_occurences = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (self.strong, self.translation_id))
+        
+        cleaned_occurences = {}
+
+        for strong_node_id, text_node_id, strongs_text in all_occurences:
+            if cleaned_occurences.get(strongs_text):
+                cleaned_occurences[strongs_text].append(Assembler(manager=self.manager, node_id=strong_node_id, scope="verse"))
+            else:
+                cleaned_occurences[strongs_text] = [Assembler(manager=self.manager, node_id=strong_node_id, scope="verse")]
+        
+        self.details["occurences"] = cleaned_occurences
 
     def get_strong_data(self):
         info = self.db.fetch_one(self.SQL.get("get_strong_data"), (self.strong,))
@@ -121,4 +125,5 @@ class Strongs():
         pass
         
 if __name__ == "__main__":
-    Strongs(ManagerHandler(), "H1254", 1)
+    temp = Strongs(ManagerHandler(), "H1254", 1)
+    print(temp.get_details())

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -89,6 +89,9 @@ class Strongs():
     
     def get_occurences(self, key:str=None, display=False, count=False, verses=False, words=False):
         # Combinations (priority order):
+
+        # Key => Unique word
+
         #   - words             =>  Unique Word Occurences
         #   - count + key       =>  Number of unique occurences for specified Unique Word
         #   - display           -> Print Each occurence to console (MODIFY IN FUTURE TO EXPORT TO MARKDOWN IN OBSIDIAN), EXCEPTIONS: [words, count + key]
@@ -107,10 +110,12 @@ class Strongs():
         unique_verses = set()
 
         #  =>  Unique Word Occurences
+        all_keys = self.details["occurences"].keys()
+        sorted_keys = sorted(all_keys, key=str.lower)
         if words and not count: 
-            return self.details["occurences"].keys()
+            return sorted_keys
 
-        for this_key in self.details["occurences"].keys():
+        for this_key in sorted_keys:
             results = self.details["occurences"].get(this_key)
 
             if key:
@@ -143,13 +148,14 @@ class Strongs():
                         unique_verses.add(assembled_verse)
 
         if verses:
+            sorted_unqiue_verses = sorted(unique_verses, key=lambda v: (v.get_details("book"), v.get_details("chapter"), v.get_details("verse")))
             if display:
-                for verse in unique_verses:
+                for verse in sorted_unqiue_verses:
                     print(verse.get_details("full_ref"))
-            return unique_verses
+            return sorted_unqiue_verses
 
         if count and words:
-            return unique_counts
+            return sorted(unique_counts, key=lambda c: c[0].lower())
         
         return results
     
@@ -194,7 +200,10 @@ class Strongs():
     def write_to_obsidian(self):
         pass
 
-def test_Strongs(object: Strongs, test_case):
+def test_Strongs(object: Strongs, test_case, excluded=[]):
+    if test_case in excluded:
+        print("EXCLUDED! Skipping...")
+        return
        
     match test_case:
         # ==================================================== SUCCESS Test Cases ====================================================
@@ -292,4 +301,4 @@ if __name__ == "__main__":
 
     for test_case in range(0, 10):
         print(f"\n==================================================== TEST: {test_case} ====================================================\n")
-        test_Strongs(temp, test_case)
+        test_Strongs(temp, test_case, [2])

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from manager.managerhandler import ManagerHandler
 
 from tokeniser.assembler import Assembler
@@ -148,7 +150,7 @@ class Strongs():
                         unique_verses.add(assembled_verse)
 
         if verses:
-            sorted_unqiue_verses = sorted(unique_verses, key=lambda v: (v.get_details("book"), v.get_details("chapter"), v.get_details("verse")))
+            sorted_unqiue_verses = sorted(unique_verses, key=lambda v: self.assembler_key(v))
             if display:
                 for verse in sorted_unqiue_verses:
                     print(verse.get_details("full_ref"))
@@ -157,7 +159,49 @@ class Strongs():
         if count and words:
             return sorted(unique_counts, key=lambda c: c[0].lower())
         
-        return results
+        # FOR WHEN NOTHING SET, return all occurences by verse and the words that occur
+
+        verse_index = defaultdict(lambda: {
+            "assembler": set(),
+            "words": set(),
+        })
+
+        # Set new dict structure where we store results by key (GEN 1:1) with assembler and words as the values
+        for word, assemblers in self.details["occurences"].items():
+            for assembler in assemblers:
+                verse_ref = assembler.get_details("ref")   # e.g. "GEN 1:1"
+
+                verse_index[verse_ref]["assembler"].add(assembler)
+                verse_index[verse_ref]["words"].add(word)
+
+        # OLD METHOD, just returns sorted version of self.details["occurences"]
+        # for k in sorted_keys:
+        #     occurences = self.details["occurences"].get(k)
+        #     sorted_results[k] = sorted(occurences, key=lambda v: (v.get_details("book"), v.get_details("chapter"), v.get_details("verse")))
+        
+        sorted_results = {}
+        # Then we sort the new dict by key, which retuns a list
+        sorted_results = sorted(
+            verse_index.items(), 
+            key=lambda item: self.assembler_key(
+                next(
+                    iter(
+                        item[1]["assembler"]
+                    )
+                )
+            )
+        )
+
+        final_dict = {}
+
+        # we then turn it back into a dict
+        for k, d in sorted_results:
+            final_dict[k] = d
+
+        return final_dict
+    
+    def assembler_key(self, a):
+        return (a.get_details("book"), a.get_details("chapter"), a.get_details("verse"))
     
     def search_strongs(self):
         # Find all unique words that use this strong code
@@ -282,8 +326,8 @@ def test_Strongs(object: Strongs, test_case, excluded=[]):
                 words=False,
                 display=False
             )
-            for r in result:
-                print(r.get_details("full_ref"))
+            for k, r in result.items():
+                print(k, r)
             print(result)
     
     # match test_case:
@@ -315,10 +359,10 @@ if __name__ == "__main__":
     temp = Strongs(ManagerHandler(), "H1254", 1)
     test_case = -1
 
-    excluded_test = [2]
+    excluded_test = []
     all_tests = range(0, 10)
+    # all_tests = [7]
 
-    all_tests = [7]
     for test_case in all_tests:
         if test_case in excluded_test: continue
         print(f"\n==================================================== TEST: {test_case} ====================================================\n")

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -19,6 +19,9 @@ class Strongs():
             GROUP BY n.node_text
             ORDER BY occurrence_count DESC;
         """,
+        "get_strong_data": """
+            SELECT * FROM bible.lexemes WHERE strongs_code = %s
+        """
     }
 
     def __init__(self, manager: ManagerHandler, strong, translation_id):
@@ -33,12 +36,17 @@ class Strongs():
         }
 
         self.search_strongs()
+        self.get_strong_data()
 
     def search_strongs(self):
         # Find all unique words that use this strong code
         unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (self.strong, self.translation_id))
         for word in unique_words:
             print(word)
+
+    def get_strong_data(self):
+        info = self.db.fetch_all(self.SQL.get("get_strong_data"), (self.strong,))
+        print(info)
 
 if __name__ == "__main__":
     Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -86,6 +86,8 @@ class Strongs():
         return self.connected_relations
     
     def get_occurences(self, key:str=None, display=False, count=False, unique=False):
+        if not self.details.get("occurences"): return None
+        
         valid = True
         unique_counts = []
         for this_key in self.details["occurences"].keys():

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -150,6 +150,9 @@ class Strongs():
         for relation_lexeme_id, strongs_code, native_word, lemma, raw_pos, transliteration, pronunciation, raw_gloss in relations:
             if strongs_code != self.strong:
                 all_relations.add(strongs_code)
+
+    def write_to_obsidian(self):
+        pass
         
 if __name__ == "__main__":
     Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -208,69 +208,83 @@ def test_Strongs(object: Strongs, test_case, excluded=[]):
     match test_case:
         # ==================================================== SUCCESS Test Cases ====================================================
         case 0: #   - words             =>  Unique Word Occurences
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=False, 
                 words=True,
                 display=False
-            ))
+            )
+            print(result)
         case 1: #   - count + key       =>  Number of unique occurences for specified Unique Word
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key="created", 
                 count=True, 
                 verses=False, 
                 words=False,
                 display=False
-            ))
+            )
+            print(result)
         case 2: #   - display           -> Print Each occurence to console (MODIFY IN FUTURE TO EXPORT TO MARKDOWN IN OBSIDIAN), EXCEPTIONS: [words, count + key]
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=False, 
                 words=False,
                 display=True
-            ))
+            )
+            print(result)
         case 3: #   - count + words     =>  Unique Word Occurences + Number of occurences for each unique word
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=True, 
                 verses=False, 
                 words=True,
                 display=False
-            ))
+            )
+            print(result)
         case 4: #   - verses            =>  Unique Verses with Occurences
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 
                 words=False,
                 display=False
-            ))
+            )
+            for r in result:
+                print(r.get_details("full_ref"))
+            print(result)
         case 5: #   - verses + key      =>  Unique Verses with specified Unique Word
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key="created", 
                 count=False, 
                 verses=True, 
                 words=False,
                 display=False
-            ))
+            )
+            for r in result:
+                print(r.get_details("full_ref"))
+            print(result)
         case 6: #   - display + verses  -> To see specifically the unique verses included
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 
                 words=False,
                 display=True
-            ))
+            )
+            print(result)
         case 7: #   - NONE              =>  Unique Word Occurences with their Unique Verse Occurences (one verse can be mentioned multiple times across unique words)
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=False, 
                 words=False,
                 display=False
-            ))
+            )
+            for r in result:
+                print(r.get_details("full_ref"))
+            print(result)
     
     # match test_case:
         # ==================================================== EDGE Test Cases ====================================================
@@ -279,21 +293,23 @@ def test_Strongs(object: Strongs, test_case, excluded=[]):
     match test_case:
         # ==================================================== FAILED Test Cases ====================================================
         case 8: #   - verses + words
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 
                 words=True,
                 display=False
-            ))
+            )
+            print(result)
         case 9: #   - key + words
-            print(object.get_occurences(
+            result = object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 
                 words=True,
                 display=False
-            ))
+            )
+            print(result)
         
 if __name__ == "__main__":
     temp = Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -27,97 +27,77 @@ class Strongs():
             SELECT * FROM bible.lexemes WHERE strongs_code = %s
         """,
         "get_strongs_relation": """
-            WITH target_lexeme AS (
+            WITH target AS (
                 SELECT id
                 FROM bible.lexemes
                 WHERE strongs_code = %s
+            ),
+            edges AS (
+                SELECT
+                    lr.relation_type,
+                    lr.from_lexeme AS source_id,
+                    lr.to_lexeme   AS target_id
+                FROM bible.lexeme_relations lr
+                JOIN target t ON lr.from_lexeme = t.id
+
+                UNION ALL
+
+                SELECT
+                    lr.relation_type,
+                    lr.to_lexeme   AS source_id,
+                    lr.from_lexeme AS target_id
+                FROM bible.lexeme_relations lr
+                JOIN target t ON lr.to_lexeme = t.id
             )
-            SELECT
-                lr.relation_type,
-                --lr.confidence,
-                --lr.notes,
+            SELECT DISTINCT
+                e.relation_type,
 
-                l_from.id            AS from_id,
-                l_from.strongs_code  AS from_strongs,
-                l_from.lemma         AS from_lemma,
+                lf.id           AS from_id,
+                lf.strongs_code AS from_strongs,
+                lf.lemma        AS from_lemma,
 
-                l_to.id              AS to_id,
-                l_to.strongs_code    AS to_strongs,
-                l_to.lemma           AS to_lemma
-            FROM bible.lexeme_relations lr
-            JOIN target_lexeme t
-            ON lr.from_lexeme = t.id
-            OR lr.to_lexeme   = t.id
-            JOIN bible.lexemes l_from ON l_from.id = lr.from_lexeme
-            JOIN bible.lexemes l_to   ON l_to.id   = lr.to_lexeme;
+                lt.id           AS to_id,
+                lt.strongs_code AS to_strongs,
+                lt.lemma        AS to_lemma
+            FROM edges e
+            JOIN bible.lexemes lf ON lf.id = e.source_id
+            JOIN bible.lexemes lt ON lt.id = e.target_id;
         """
     }
 
-    def __init__(self, manager: ManagerHandler, strong, translation_id, recursive_limit:int=3, recursive_depth:int=0, parent_object: "Strongs" = None):
+    def __init__(self, manager: ManagerHandler, strong, translation_id):
         self.manager = manager
         self.db = manager.get_db()
 
-        self.parent_object = parent_object
-
         self.strong = strong
         self.translation_id = translation_id
-        self.recursive_depth = recursive_depth
-        self.recursive_limit = recursive_limit
         
         self.details = {}
-        self.all_objects = {}
 
         self.search_strongs()
         self.get_strong_data()
 
-        self.root = False
-        if recursive_depth == 0:
-            self.root = True
-            self.set_new_child_object(self.strong, self)
-        else:
-            self.get_root().set_new_child_object(self.strong, self)
-
-        self.connected_relations = {}
+        self.connected_relations = set()
         # Create local version for this object, where you link the object if its already been created.
 
         self.strongs_recursion()
-
-    def get_root(self):
-        strong_object = self
-        while not strong_object.is_root():
-            strong_object = strong_object.get_parent_object()
-
-        return strong_object
-    
-    def get_object_in_root(self, strongs_code):
-        if self.root:
-            return self.all_objects.get(strongs_code)
-        
-        return None
-
-    def get_parent_object(self):
-        return self.parent_object
-
-    def is_root(self):
-        return self.root
     
     def get_strong(self):
         return self.strong
     
-    def get_details(self):
+    def get_details(self, key:str = None):
+        if key:
+            return self.details.get(key)
+        
         return self.details
     
     def get_connected_relations(self):
         return self.connected_relations
     
-    def set_new_child_object(self, strongs_code:str, object:"Strongs"):
-        # Basically add all created child roots, but only if already exists
-        if self.root:
-            self.all_objects[strongs_code]
-
     def search_strongs(self):
         # Find all unique words that use this strong code
-        unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (self.strong, self.translation_id))
+        unique_words = self.db.fetch_all_single(self.SQL.get("get_unique_strong_text"), (self.strong, self.translation_id))
+        self.details["occurences"] = unique_words
         for word in unique_words:
             print(word)
 
@@ -128,8 +108,6 @@ class Strongs():
         self.details["code"] = self.strong
         self.details["pos"] = info[7]
         self.details["gloss"] = info[11]
-
-        self.all_objects[self.strong] = self
 
     def strongs_recursion(self):
         lexeme_id = self.details["id"]
@@ -145,16 +123,8 @@ class Strongs():
             
             if to_strongs != self.strong:
                 all_relations.add(to_strongs)
-        
-        # Before creating a new object find out whether it's already been created in the recursive stack by someone else
-        for relation in all_relations:
-            new_depth = self.recursive_depth+1
-            if new_depth <= self.recursive_limit:
-                existing_object = self.get_root().get_object_in_root(relation)
-                if existing_object:
-                    self.connected_relations[relation] = existing_object
-                else:
-                    self.connected_relations[relation] = Strongs(self.manager, relation, self.translation_id, self.recursive_limit, new_depth)
+
+        self.connected_relations = all_relations
 
 if __name__ == "__main__":
     Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -26,30 +26,36 @@ class Strongs():
         "get_strong_data": """
             SELECT * FROM bible.lexemes WHERE strongs_code = %s
         """,
-        "get_strongs_relation": """
-            WITH target_lexeme AS (
-                SELECT id
-                FROM bible.lexemes
-                WHERE strongs_code = %s
-            )
-            SELECT
-                lr.relation_type,
-                --lr.confidence,
-                --lr.notes,
+        "get_strongs_to_relation": """
+            SELECT 
+                lr.to_lexeme, 
+                l.strongs_code,
+                l.native_word,
+                l.lemma,
+                l.raw_pos,
+                l.transliteration,
+                l.pronunciation,
+                l.raw_gloss
+            FROM bible.lexemes l
+            JOIN bible.lexeme_relations lr ON l.id = lr.to_lexeme
+            WHERE lr.from_lexeme = %s
+        """,
+        "get_strongs_from_relation": """
+            SELECT 
+                lr.from_lexeme, 
+                l.strongs_code,
+                l.native_word,
+                l.lemma,
+                l.raw_pos,
+                l.transliteration,
+                l.pronunciation,
+                l.raw_gloss
+            FROM bible.lexemes l
+            JOIN bible.lexeme_relations lr ON l.id = lr.from_lexeme
+            WHERE lr.to_lexeme = %s
+        """,
+        "": """"
 
-                l_from.id            AS from_id,
-                l_from.strongs_code  AS from_strongs,
-                l_from.lemma         AS from_lemma,
-
-                l_to.id              AS to_id,
-                l_to.strongs_code    AS to_strongs,
-                l_to.lemma           AS to_lemma
-            FROM bible.lexeme_relations lr
-            JOIN target_lexeme t
-            ON lr.from_lexeme = t.id
-            OR lr.to_lexeme   = t.id
-            JOIN bible.lexemes l_from ON l_from.id = lr.from_lexeme
-            JOIN bible.lexemes l_to   ON l_to.id   = lr.to_lexeme;
         """
     }
 
@@ -133,28 +139,17 @@ class Strongs():
 
     def strongs_recursion(self):
         lexeme_id = self.details["id"]
-        relations = self.db.fetch_all(self.SQL.get("get_strongs_relation"), (self.strong,))
-        # print(relations)
+        to_relations = self.db.fetch_all(self.SQL.get("get_strongs_to_relation"), (lexeme_id,))
+        from_relations = self.db.fetch_all(self.SQL.get("get_strongs_from_relation"), (lexeme_id,))
+        relations = to_relations + from_relations
+        print(relations)
         # print("===========================")
 
         all_relations = set()
-        
-        for relation_type, from_id, from_strongs, from_lemma, to_id, to_strongs, to_lemma in relations:
-            if from_strongs != self.strong:
-                all_relations.add(from_strongs)
-            
-            if to_strongs != self.strong:
-                all_relations.add(to_strongs)
-        
-        # Before creating a new object find out whether it's already been created in the recursive stack by someone else
-        for relation in all_relations:
-            new_depth = self.recursive_depth+1
-            if new_depth <= self.recursive_limit:
-                existing_object = self.get_root().get_object_in_root(relation)
-                if existing_object:
-                    self.connected_relations[relation] = existing_object
-                else:
-                    self.connected_relations[relation] = Strongs(self.manager, relation, self.translation_id, self.recursive_limit, new_depth)
 
+        for relation_lexeme_id, strongs_code, native_word, lemma, raw_pos, transliteration, pronunciation, raw_gloss in relations:
+            if strongs_code != self.strong:
+                all_relations.add(strongs_code)
+        
 if __name__ == "__main__":
     Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -6,14 +6,18 @@ class Strongs():
             WITH strongs_nodes AS (
                 SELECT id
                 FROM bible.nodes
-                WHERE strong = %s
+                WHERE strong = %s AND translation_id = %s
             )
-            SELECT DISTINCT n.node_text
+            SELECT
+                n.node_text,
+                COUNT(*) AS occurrence_count
             FROM bible.nodes n
             JOIN strongs_nodes sn
             ON n.parent_node_id = sn.id
             WHERE n.node_text IS NOT NULL
-            AND n.node_text <> '';
+            AND n.node_text <> ''
+            GROUP BY n.node_text
+            ORDER BY occurrence_count DESC;
         """,
     }
 
@@ -32,9 +36,9 @@ class Strongs():
 
     def search_strongs(self):
         # Find all unique words that use this strong code
-        unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (self.strong,))
+        unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (self.strong, self.translation_id))
         for word in unique_words:
             print(word)
 
-if __name__ == "__main":
-    Strongs(ManagerHandler())
+if __name__ == "__main__":
+    Strongs(ManagerHandler(), "H1254", 1)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -315,6 +315,11 @@ if __name__ == "__main__":
     temp = Strongs(ManagerHandler(), "H1254", 1)
     test_case = -1
 
-    for test_case in range(0, 10):
+    excluded_test = [2]
+    all_tests = range(0, 10)
+
+    all_tests = [7]
+    for test_case in all_tests:
+        if test_case in excluded_test: continue
         print(f"\n==================================================== TEST: {test_case} ====================================================\n")
-        test_Strongs(temp, test_case, [2])
+        test_Strongs(temp, test_case, excluded_test)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -85,6 +85,42 @@ class Strongs():
     def get_connected_relations(self):
         return self.connected_relations
     
+    def get_occurences(self, key:str=None, display=False, count=False, unique=False):
+        valid = True
+        unique_counts = []
+        for this_key in self.details["occurences"].keys():
+            if key:
+                if key == this_key:
+                    valid = True
+                else:
+                    valid = False
+
+            if valid:
+                results = self.details["occurences"].get(this_key)
+                # if count and unique active, return the count of each unique occurence
+                if count and unique:
+                    unique_counts.append([this_key, len(results)])
+
+                # Can only properly return count of occurence when selecting specific one
+                elif count and key: 
+                    return len(results)
+                
+                # Returns all unique text occurences
+                elif unique:
+                    return results.keys()
+                
+                # If display enable, will print results to console for viewing
+                if display:
+                    for assembled_verse in results:
+                        full_ref = assembled_verse.get_details("full_ref")
+                        text = assembled_verse.get_details("text")
+                        print(f"\n{full_ref} => [{text}]\n")
+
+        if count and unique:
+            return 
+        
+        return results
+    
     def search_strongs(self):
         # Find all unique words that use this strong code
         all_occurences = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (self.strong, self.translation_id))
@@ -126,4 +162,5 @@ class Strongs():
         
 if __name__ == "__main__":
     temp = Strongs(ManagerHandler(), "H1254", 1)
-    print(temp.get_details())
+    # print(temp.get_details())
+    temp.get_occurences(display=True)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -87,10 +87,20 @@ class Strongs():
         return self.connected_relations
     
     def get_occurences(self, key:str=None, display=False, count=False, unique=False):
+        # Combinations:
+        #   - count + unique    =>  Unique Word Occurences + Number of occurences for each unique word
+        #   - count + key       =>  Number of unique occurences for specified Unique Word
+        #   - unique            =>  Unique Verses with Occurences
+        #   - unique + key      =>  Unique Word Occurences (any key that is NOT None)
+
+        #   - display (doesn't affect others) -> Print Each occurence to console (MODIFY IN FUTURE TO EXPORT TO MARKDOWN IN OBSIDIAN)
+
         if not self.details.get("occurences"): return None
 
         valid = True
         unique_counts = []
+        unique_verses = set()
+
         for this_key in self.details["occurences"].keys():
             if key:
                 if key == this_key:
@@ -110,7 +120,11 @@ class Strongs():
                 
                 # Returns all unique text occurences
                 elif unique:
-                    return results.keys()
+                    if key:
+                        return results.keys()
+                    else:
+                        for assembled_verse in results:
+                            unique_verses.add(assembled_verse)
                 
                 # If display enable, will print results to console for viewing
                 if display:
@@ -119,8 +133,11 @@ class Strongs():
                         text = assembled_verse.get_details("text")
                         print(f"\n{full_ref} => [{this_key}] => [{text}]\n")
 
+        if unique:
+            return unique_verses
+
         if count and unique:
-            return 
+            return unique_counts
         
         return results
     

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -86,57 +86,68 @@ class Strongs():
     def get_connected_relations(self):
         return self.connected_relations
     
-    def get_occurences(self, key:str=None, display=False, count=False, unique=False):
-        # Combinations:
-        #   - count + unique    =>  Unique Word Occurences + Number of occurences for each unique word
+    def get_occurences(self, key:str=None, display=False, count=False, verses=False, words=False):
+        # Combinations (priority order):
+        #   - words             =>  Unique Word Occurences
         #   - count + key       =>  Number of unique occurences for specified Unique Word
-        #   - unique            =>  Unique Verses with Occurences
-        #   - unique + key      =>  Unique Word Occurences (any key that is NOT None)
-
-        #   - display (doesn't affect others) -> Print Each occurence to console (MODIFY IN FUTURE TO EXPORT TO MARKDOWN IN OBSIDIAN)
+        #   - display           -> Print Each occurence to console (MODIFY IN FUTURE TO EXPORT TO MARKDOWN IN OBSIDIAN), EXCEPTIONS: [words, count + key]
+        #   - count + words     =>  Unique Word Occurences + Number of occurences for each unique word
+        #   - verses            =>  Unique Verses with Occurences
+        #   - verses + key      =>  Unique Verses with specified Unique Word
+        #   - display + verses  -> To see specifically the unique verses included
+        #   - NONE              =>  Unique Word Occurences with their Unique Verse Occurences (one verse can be mentioned multiple times across unique words)
 
         if not self.details.get("occurences"): return None
+        if key and words: return None
+        if verses and words: return None
 
         valid = True
         unique_counts = []
         unique_verses = set()
 
+        #  =>  Unique Word Occurences
+        if words and not count: 
+            return self.details["occurences"].keys()
+
         for this_key in self.details["occurences"].keys():
+            results = self.details["occurences"].get(this_key)
+
             if key:
                 if key == this_key:
                     valid = True
                 else:
                     valid = False
 
-            if valid:
-                results = self.details["occurences"].get(this_key)
-                # if count and unique active, return the count of each unique occurence
-                if count and unique:
-                    unique_counts.append([this_key, len(results)])
+                #  =>  Number of unique occurences for specified Unique Word
+                if count: 
+                    return len(self.details["occurences"].get(key))
 
-                # Can only properly return count of occurence when selecting specific one
-                elif count and key: 
-                    return len(results)
-                
-                # Returns all unique text occurences
-                elif unique:
-                    if key:
-                        return results.keys()
-                    else:
-                        for assembled_verse in results:
-                            unique_verses.add(assembled_verse)
-                
-                # If display enable, will print results to console for viewing
-                if display:
+            if valid:
+                #  -> Print Each occurence to console
+                if display and not verses:
                     for assembled_verse in results:
                         full_ref = assembled_verse.get_details("full_ref")
                         text = assembled_verse.get_details("text")
                         print(f"\n{full_ref} => [{this_key}] => [{text}]\n")
 
-        if unique:
+                #  =>  Unique Word Occurences + Number of occurences for each unique word
+                if count and words: 
+                    unique_counts.append([this_key, len(results)])
+                
+                # ONE OF:
+                #        =>  Unique Verses with Occurences
+                # [key]  =>  Unique Verses with specified Unique Word
+                elif verses:
+                    for assembled_verse in results:
+                        unique_verses.add(assembled_verse)
+
+        if verses:
+            if display:
+                for verse in unique_verses:
+                    print(verse.get_details("full_ref"))
             return unique_verses
 
-        if count and unique:
+        if count and words:
             return unique_counts
         
         return results
@@ -183,5 +194,94 @@ class Strongs():
         
 if __name__ == "__main__":
     temp = Strongs(ManagerHandler(), "H1254", 1)
-    # print(temp.get_details())
-    temp.get_occurences(display=True)
+    test_case = -1
+        
+    match test_case:
+        # ==================================================== SUCCESS Test Cases ====================================================
+        case 0: #   - words             =>  Unique Word Occurences
+            print(temp.get_occurences(
+                key=None, 
+                count=False, 
+                verses=False, 
+                words=True,
+                display=False
+            ))
+        case 1: #   - count + key       =>  Number of unique occurences for specified Unique Word
+            print(temp.get_occurences(
+                key="created", 
+                count=True, 
+                verses=False, 
+                words=False,
+                display=False
+            ))
+        case 2: #   - display           -> Print Each occurence to console (MODIFY IN FUTURE TO EXPORT TO MARKDOWN IN OBSIDIAN), EXCEPTIONS: [words, count + key]
+            print(temp.get_occurences(
+                key=None, 
+                count=False, 
+                verses=False, 
+                words=False,
+                display=True
+            ))
+        case 3: #   - count + words     =>  Unique Word Occurences + Number of occurences for each unique word
+            print(temp.get_occurences(
+                key=None, 
+                count=True, 
+                verses=False, 
+                words=True,
+                display=False
+            ))
+        case 4: #   - verses            =>  Unique Verses with Occurences
+            print(temp.get_occurences(
+                key=None, 
+                count=False, 
+                verses=True, 
+                words=False,
+                display=False
+            ))
+        case 5: #   - verses + key      =>  Unique Verses with specified Unique Word
+            print(temp.get_occurences(
+                key="created", 
+                count=False, 
+                verses=True, 
+                words=False,
+                display=False
+            ))
+        case 6: #   - display + verses  -> To see specifically the unique verses included
+            print(temp.get_occurences(
+                key=None, 
+                count=False, 
+                verses=True, 
+                words=False,
+                display=True
+            ))
+        case 7: #   - NONE              =>  Unique Word Occurences with their Unique Verse Occurences (one verse can be mentioned multiple times across unique words)
+            print(temp.get_occurences(
+                key=None, 
+                count=False, 
+                verses=False, 
+                words=False,
+                display=False
+            ))
+    
+    # match test_case:
+        # ==================================================== EDGE Test Cases ====================================================
+        # I considered setting these up, but too cumbersome to validate, so will set to return null if conflicting configs set
+
+    match test_case:
+        # ==================================================== FAILED Test Cases ====================================================
+        case 8: #   - verses + words
+            print(temp.get_occurences(
+                key=None, 
+                count=False, 
+                verses=True, 
+                words=True,
+                display=False
+            ))
+        case 8: #   - key + words
+            print(temp.get_occurences(
+                key=None, 
+                count=False, 
+                verses=True, 
+                words=True,
+                display=False
+            ))

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -193,11 +193,9 @@ class Strongs():
 
     def write_to_obsidian(self):
         pass
-        
-if __name__ == "__main__":
-    temp = Strongs(ManagerHandler(), "H1254", 1)
-    test_case = -1
-        
+
+def test_Strongs(object: Strongs, test_case):
+       
     match test_case:
         # ==================================================== SUCCESS Test Cases ====================================================
         case 0: #   - words             =>  Unique Word Occurences
@@ -279,7 +277,7 @@ if __name__ == "__main__":
                 words=True,
                 display=False
             ))
-        case 8: #   - key + words
+        case 9: #   - key + words
             print(temp.get_occurences(
                 key=None, 
                 count=False, 
@@ -287,3 +285,11 @@ if __name__ == "__main__":
                 words=True,
                 display=False
             ))
+        
+if __name__ == "__main__":
+    temp = Strongs(ManagerHandler(), "H1254", 1)
+    test_case = -1
+
+    for test_case in range(0, 10):
+        print(f"\n==================================================== TEST: {test_case} ====================================================\n")
+        test_Strongs(temp, test_case)

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -199,7 +199,7 @@ def test_Strongs(object: Strongs, test_case):
     match test_case:
         # ==================================================== SUCCESS Test Cases ====================================================
         case 0: #   - words             =>  Unique Word Occurences
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=False, 
@@ -207,7 +207,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=False
             ))
         case 1: #   - count + key       =>  Number of unique occurences for specified Unique Word
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key="created", 
                 count=True, 
                 verses=False, 
@@ -215,7 +215,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=False
             ))
         case 2: #   - display           -> Print Each occurence to console (MODIFY IN FUTURE TO EXPORT TO MARKDOWN IN OBSIDIAN), EXCEPTIONS: [words, count + key]
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=False, 
@@ -223,7 +223,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=True
             ))
         case 3: #   - count + words     =>  Unique Word Occurences + Number of occurences for each unique word
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=True, 
                 verses=False, 
@@ -231,7 +231,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=False
             ))
         case 4: #   - verses            =>  Unique Verses with Occurences
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 
@@ -239,7 +239,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=False
             ))
         case 5: #   - verses + key      =>  Unique Verses with specified Unique Word
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key="created", 
                 count=False, 
                 verses=True, 
@@ -247,7 +247,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=False
             ))
         case 6: #   - display + verses  -> To see specifically the unique verses included
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 
@@ -255,7 +255,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=True
             ))
         case 7: #   - NONE              =>  Unique Word Occurences with their Unique Verse Occurences (one verse can be mentioned multiple times across unique words)
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=False, 
@@ -270,7 +270,7 @@ def test_Strongs(object: Strongs, test_case):
     match test_case:
         # ==================================================== FAILED Test Cases ====================================================
         case 8: #   - verses + words
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 
@@ -278,7 +278,7 @@ def test_Strongs(object: Strongs, test_case):
                 display=False
             ))
         case 9: #   - key + words
-            print(temp.get_occurences(
+            print(object.get_occurences(
                 key=None, 
                 count=False, 
                 verses=True, 

--- a/services/tokeniser/strongs.py
+++ b/services/tokeniser/strongs.py
@@ -22,7 +22,7 @@ class Strongs():
             ORDER BY p.id ASC;
         """,
         "get_strong_data": """
-            SELECT * FROM bible.lexemes WHERE strongs_code = %s
+            SELECT id, source, source_version, strongs_code, language_id, lemma, raw_pos, transliteration, pronunciation, audio_file, raw_gloss FROM bible.lexemes WHERE strongs_code = %s
         """,
         "get_strongs_to_relation": """
             SELECT 
@@ -58,11 +58,12 @@ class Strongs():
     }
 
     def __init__(self, manager: ManagerHandler, strong, translation_id):
-        self.manager = manager
-        self.db = manager.get_db()
-
         self.strong = strong
         self.translation_id = translation_id
+
+        self.manager = manager
+        self.db = manager.get_db()
+        self.log = manager.create_log_in_folder(["logs", "strongs"], self.strong)
         
         self.details = {}
 
@@ -169,19 +170,20 @@ class Strongs():
 
     def get_strong_data(self):
         info = self.db.fetch_one(self.SQL.get("get_strong_data"), (self.strong,))
-        print(info)
-        self.details["id"] = info[0] # Lexeme_id
-        self.details["code"] = self.strong
-        self.details["pos"] = info[7]
-        self.details["gloss"] = info[11]
+
+        # Mirror SELECT DB Query
+        id, source, source_version, strongs_code, language_id, lemma, raw_pos, transliteration, pronunciation, audio_file, raw_gloss = info
+
+        self.details["id"] = id # Lexeme_id
+        self.details["code"] = self.strong # or strongs_code
+        self.details["pos"] = raw_pos
+        self.details["gloss"] = raw_gloss
 
     def strongs_recursion(self):
         lexeme_id = self.details["id"]
         to_relations = self.db.fetch_all(self.SQL.get("get_strongs_to_relation"), (lexeme_id,))
         from_relations = self.db.fetch_all(self.SQL.get("get_strongs_from_relation"), (lexeme_id,))
         relations = to_relations + from_relations
-        print(relations)
-        # print("===========================")
 
         all_relations = set()
 

--- a/services/utilities/search.py
+++ b/services/utilities/search.py
@@ -52,19 +52,6 @@ class Search():
             FROM bible.nodes
             WHERE strong = %s
         """,
-        "get_unique_strong_text": """
-            WITH strongs_nodes AS (
-                SELECT id
-                FROM bible.nodes
-                WHERE strong = %s
-            )
-            SELECT DISTINCT n.node_text
-            FROM bible.nodes n
-            JOIN strongs_nodes sn
-            ON n.parent_node_id = sn.id
-            WHERE n.node_text IS NOT NULL
-            AND n.node_text <> '';
-        """,
         "get_strongs_occurences_per_translation" : """
             SELECT 
                 sn.strong,
@@ -277,11 +264,6 @@ class Search():
     def search_strongs(self, strong):
         # Find strongs occurences
         nodes_found = self.db.fetch_all(self.SQL.get("get_strong_nodes"), (strong,))
-
-        # Find all unique words that use this strong code
-        unique_words = self.db.fetch_all(self.SQL.get("get_unique_strong_text"), (strong,))
-        for word in unique_words:
-            print(word)
 
         results = self.search_results(nodes_found, config=["full_ref", "translation", "text"])
 


### PR DESCRIPTION
# What?
As part of #35, where we now Implemented and made improvements to Assembler by adding an additional Strongs version that would allow you to search a word by strongs number and get various data about its occurences back, whether that be the amount of mentions or returning verse occurences.

# Why?
This would help to do searches as well exploratory reading of the Bible. Eventually it would also serve as a way to help do data visualisation on this information

# Notes
- Added Paperless-ngx docker container to the system for viewing files inside minio storage in the future? Not sure how that would work, but could perhaps make them point at the same directory where they store files, instead of having to download to view minio files
- As mentioned in #35 strongs in USX has been found to be limited and thus difficult to completely get all occurences, but its a starting point at least.

# Future Improvements
- [x] Returning Verse Occurences in order (Genesis - Revelations)
- [ ] Map to original language => we already store llema or root -> find in Hebrew or Greek translation -> map or identify Strongs alternatively
- [ ] Combine with tokenisation to supplement results
- [ ] On the back of this create a similar but variant version around Tokens