### PR TITLE
feature: BIL-84: SIL codes schema

### DIFF
--- a/services/database/boundary/usx_boundary.py
+++ b/services/database/boundary/usx_boundary.py
@@ -398,7 +398,7 @@ class USXWriteBoundary(WriteBoundary):
         ) -> int:
         query = """
             INSERT INTO audit.files (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash) 
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id;
         """
         file_id = self.db.fetch_clean_one(query, (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash))

--- a/services/database/server/schemas/core/schemas.sql
+++ b/services/database/server/schemas/core/schemas.sql
@@ -10,3 +10,5 @@ CREATE SCHEMA entity;       -- people, places, objects, events | asserted real-w
 CREATE SCHEMA geo;          -- spatial data & mappings
 CREATE SCHEMA measure;      -- units, systems, conversions
 CREATE SCHEMA structure;    -- chronology, harmony, outlines
+
+CREATE SCHEMA sil;

--- a/services/database/server/schemas/metadata/label_studio.sql
+++ b/services/database/server/schemas/metadata/label_studio.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS nlp.translation_labelling_projects (
     translation_id      INTEGER,
     project_id          INTEGER,
     FOREIGN KEY (translation_id) REFERENCES bible.translations (id) ON DELETE CASCADE,
-    FOREIGN KEY (project_id) REFERENCES nlp.labellingprojects (id) ON DELETE CASCADE
+    FOREIGN KEY (project_id) REFERENCES nlp.labelling_projects (id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS nlp.labelling_files (

--- a/services/database/server/schemas/reference/languages.sql
+++ b/services/database/server/schemas/reference/languages.sql
@@ -1,3 +1,5 @@
+
+-- TO BE DEPRACATED
 CREATE TABLE IF NOT EXISTS language.languages (
     id                  SERIAL PRIMARY KEY,
     iso                 TEXT UNIQUE, -- Follows ISO 639-3:2007 format? 

--- a/services/database/server/schemas/reference/translations.sql
+++ b/services/database/server/schemas/reference/translations.sql
@@ -9,6 +9,10 @@ CREATE TABLE IF NOT EXISTS audit.dbl_info (
     CHECK (revision >= 0)
 );
 
+-- TO BE AMENDED: 
+--      Add language ID from sil.iso_codes instead
+--      Add Script ID from unicode.
+--      (Optional) Add CLRD (Numeric system used in translation)
 CREATE TABLE IF NOT EXISTS bible.translations (
     id                  SERIAL PRIMARY KEY,
     dbl_id              TEXT,

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -1,0 +1,112 @@
+-- MODIFED FROM: https://iso639-3.sil.org/code_tables/download_tables
+
+-- ============================================================================
+-- ISO 639-3 Codes
+-- ============================================================================
+
+CREATE TABLE sil.iso_codes (
+    id          char(3) NOT NULL,  -- The three-letter 639-3 identifier
+    part2b      char(3) NULL,      -- Equivalent 639-2 identifier of the bibliographic applications (if there is one)
+    part2t      char(3) NULL,      -- Equivalent 639-2 identifier of the terminology applications code (if there is one)
+    part1       char(2) NULL,      -- Equivalent 639-1 identifier, (if there is one)
+    scope       char(1) NOT NULL, 
+    type        char(1) NOT NULL,
+    ref_name    varchar(150) NOT NULL,   -- Reference language name 
+    comment     varchar(150) NULL,       -- Comment relating to one or more of the columns
+    FOREIGN KEY (scope) REFERENCES sil.iso_scopes (id),
+    FOREIGN KEY (type) REFERENCES sil.iso_types (id)
+);
+
+CREATE TABLE sil.scopes (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT
+);
+
+INSERT VALUES INTO sil.iso_scopes (code, name, description)
+VALUES 
+    ('I', 'Individual', ''),
+    ('M', 'Macrolanguage', ''),
+    ('S', 'Special', '');
+
+CREATE TABLE sil.iso_types (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT
+);
+
+INSERT VALUES INTO sil.types (code, name, description)
+VALUES 
+    ('A', 'Ancient', ''),
+    ('C', 'Constructed', ''),
+    ('E', 'Extinct', ''),
+    ('H', 'Histrical', ''),
+    ('L', 'Living', ''),
+    ('S', 'Special', '');
+
+-- ============================================================================
+-- ISO 639-3 Code Language Names
+-- ============================================================================
+
+CREATE TABLE sil.iso_names (
+    iso_code        char(3)     PRIMARY KEY,    -- The three-letter 639-3 identifier
+    print_name      varchar(75) NOT NULL,       -- One of the names associated with this identifier 
+    inverted_name   varchar(75) NOT NULL,       -- The inverted form of this Print_Name form   
+    FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id)
+); 
+
+-- ============================================================================
+-- ISO 639-3 Macrolanguage Codes
+-- ============================================================================
+
+CREATE TABLE sil.macrolanguages (
+    macro_id            char(3) PRIMARY KEY,    -- The identifier for a macrolanguage
+    iso_id              char(3) NOT NULL,       -- The identifier for an individual language that is a member of the macrolanguage
+    iso_status          char(1) NOT NULL,       -- A (active) or R (retired) indicating the status of the individual code element
+    FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (iso_status) REFERENCES sil.macro_status (id)
+);
+
+CREATE TABLE sil.macro_status (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT
+);
+
+INSERT VALUES INTO sil.macro_status (code, name, description)
+VALUES 
+    ('A', 'Active', ''),
+    ('R', 'Retired', '');
+
+-- ============================================================================
+-- ISO 639-3 Retirements (/Depracated)
+-- ============================================================================
+
+CREATE TABLE sil.retirements (
+    id                  SERIAL PRIMARY KEY,
+    iso_code            char(3)      NOT NULL,      -- The three-letter 639-3 identifier
+    ref_name            varchar(150) NOT NULL,      -- reference name of language
+    retired_reason      char(1)      NOT NULL,
+    changed_to          char(3)      NULL,          -- in the cases of C, D, and M, the identifier to which all instances of this Id should be changed
+    retired_remedy      varchar(300) NULL,          -- The instructions for updating an instance of the retired (split) identifier
+    Effective           DATE        NOT NULL,       -- The date the retirement became effective
+    FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id),
+    -- FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
+);
+
+CREATE TABLE lookup.retirement_reasons (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    description     TEXT
+)
+
+INSERT INTO sil.retirement_reasons (code, name, description)
+VALUES
+    -- Associated with Change_To
+    ('C', 'Change', ''),
+    ('D', 'Duplicate', ''),
+    ('M', 'Merge', ''),
+    -- Exists independently
+    ('N', 'Non-existent', ''),
+    ('S', 'Split', '');

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -99,7 +99,7 @@ CREATE TABLE sil.retirement_reasons (
     id              char(1) PRIMARY KEY,
     name            TEXT NOT NULL,
     description     TEXT NOT NULL
-)
+);
 
 INSERT INTO sil.retirement_reasons (id, name, description)
 VALUES

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -5,20 +5,20 @@
 -- ============================================================================
 
 CREATE TABLE sil.iso_codes (
-    id          char(3) NOT NULL,  -- The three-letter 639-3 identifier
-    part2b      char(3) NULL,      -- Equivalent 639-2 identifier of the bibliographic applications (if there is one)
-    part2t      char(3) NULL,      -- Equivalent 639-2 identifier of the terminology applications code (if there is one)
-    part1       char(2) NULL,      -- Equivalent 639-1 identifier, (if there is one)
+    id          char(3) NOT NULL,       -- The three-letter 639-3 identifier
+    part2b      char(3) NULL,           -- Equivalent 639-2 identifier of the bibliographic applications (if there is one)
+    part2t      char(3) NULL,           -- Equivalent 639-2 identifier of the terminology applications code (if there is one)
+    part1       char(2) NULL,           -- Equivalent 639-1 identifier, (if there is one)
     scope       char(1) NOT NULL, 
     type        char(1) NOT NULL,
-    ref_name    varchar(150) NOT NULL,   -- Reference language name 
-    comment     varchar(150) NULL,       -- Comment relating to one or more of the columns
+    ref_name    varchar(150) NOT NULL,  -- Reference language name 
+    comment     varchar(150) NULL,      -- Comment relating to one or more of the columns
     FOREIGN KEY (scope) REFERENCES sil.iso_scopes (id),
     FOREIGN KEY (type) REFERENCES sil.iso_types (id)
 );
 
-CREATE TABLE sil.scopes (
-    id          TEXT PRIMARY KEY,
+CREATE TABLE sil.iso_scopes (
+    id          char(1) PRIMARY KEY,
     name        TEXT NOT NULL,
     description TEXT
 );
@@ -30,12 +30,12 @@ VALUES
     ('S', 'Special', '');
 
 CREATE TABLE sil.iso_types (
-    id          TEXT PRIMARY KEY,
+    id          char(1) PRIMARY KEY,
     name        TEXT NOT NULL,
     description TEXT
 );
 
-INSERT VALUES INTO sil.types (code, name, description)
+INSERT VALUES INTO sil.iso_types (code, name, description)
 VALUES 
     ('A', 'Ancient', ''),
     ('C', 'Constructed', ''),
@@ -49,9 +49,10 @@ VALUES
 -- ============================================================================
 
 CREATE TABLE sil.iso_names (
-    iso_code        char(3)     PRIMARY KEY,    -- The three-letter 639-3 identifier
-    print_name      varchar(75) NOT NULL,       -- One of the names associated with this identifier 
-    inverted_name   varchar(75) NOT NULL,       -- The inverted form of this Print_Name form   
+    id              SERIAL PRIMARY KEY,
+    iso_code        char(3)     NOT NULL,   -- The three-letter 639-3 identifier
+    print_name      varchar(75) NOT NULL,   -- One of the names associated with this identifier 
+    inverted_name   varchar(75) NOT NULL,   -- The inverted form of this Print_Name form   
     FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id)
 ); 
 
@@ -60,15 +61,16 @@ CREATE TABLE sil.iso_names (
 -- ============================================================================
 
 CREATE TABLE sil.macrolanguages (
-    macro_id            char(3) PRIMARY KEY,    -- The identifier for a macrolanguage
-    iso_id              char(3) NOT NULL,       -- The identifier for an individual language that is a member of the macrolanguage
-    iso_status          char(1) NOT NULL,       -- A (active) or R (retired) indicating the status of the individual code element
+    macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
+    iso_id              char(3) NOT NULL,   -- The identifier for an individual language that is a member of the macrolanguage
+    iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
+    PRIMARY KEY (macro_id, iso_id)
     FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (iso_status) REFERENCES sil.macro_status (id)
 );
 
 CREATE TABLE sil.macro_status (
-    id          TEXT PRIMARY KEY,
+    id          char(1) PRIMARY KEY,
     name        TEXT NOT NULL,
     description TEXT
 );
@@ -92,11 +94,12 @@ CREATE TABLE sil.retirements (
     Effective           DATE        NOT NULL,       -- The date the retirement became effective
     FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id),
+    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
     -- FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
 );
 
 CREATE TABLE lookup.retirement_reasons (
-    id              TEXT PRIMARY KEY,
+    id              char(1) PRIMARY KEY,
     name            TEXT NOT NULL,
     description     TEXT
 )

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -23,7 +23,7 @@ CREATE TABLE sil.iso_scopes (
     description     TEXT NOT NULL
 );
 
-INSERT INTO sil.iso_scopes (code, name, description)
+INSERT INTO sil.iso_scopes (id, name, description)
 VALUES 
     ('I', 'Individual',     'Represents a single, distinct language'),
     ('M', 'Macrolanguage',  'Represents a macrolanguage rather than an individual language'),
@@ -35,7 +35,7 @@ CREATE TABLE sil.iso_types (
     description     TEXT NOT NULL
 );
 
-INSERT INTO sil.iso_types (code, name, description)
+INSERT INTO sil.iso_types (id, name, description)
 VALUES 
     ('A', 'Ancient',        'Known only from historical records'),
     ('C', 'Constructed',    'Artificially created language'),
@@ -75,7 +75,7 @@ CREATE TABLE sil.macro_status (
     description     TEXT NOT NULL
 );
 
-INSERT INTO sil.macro_status (code, name, description)
+INSERT INTO sil.macro_status (id, name, description)
 VALUES 
     ('A', 'Active',     'Code is currently valid'),
     ('R', 'Retired',    'Code has been retired');
@@ -94,8 +94,7 @@ CREATE TABLE sil.retirements (
     Effective           DATE        NOT NULL,       -- The date the retirement became effective
     FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id),
-    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
-    -- FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id)
 );
 
 CREATE TABLE lookup.retirement_reasons (
@@ -104,12 +103,12 @@ CREATE TABLE lookup.retirement_reasons (
     description     TEXT NOT NULL
 )
 
-INSERT INTO sil.retirement_reasons (code, name, description)
+INSERT INTO sil.retirement_reasons (id, name, description)
 VALUES
     -- Associated with Change_To
-    ('C', 'Change', ''),
-    ('D', 'Duplicate', ''),
-    ('M', 'Merge', ''),
+    ('C', 'Change',         'Code replaced by another'),
+    ('D', 'Duplicate',      'Code duplicated another'),
+    ('M', 'Merge',          'Multiple codes merged'),
     -- Exists independently
-    ('N', 'Non-existent', ''),
-    ('S', 'Split', '');
+    ('N', 'Non-existent',   'Language determined not to exist'),
+    ('S', 'Split',          'Language split into multiple codes');

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -18,31 +18,31 @@ CREATE TABLE sil.iso_codes (
 );
 
 CREATE TABLE sil.iso_scopes (
-    id          char(1) PRIMARY KEY,
-    name        TEXT NOT NULL,
-    description TEXT
+    id              char(1) PRIMARY KEY,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL
 );
 
-INSERT VALUES INTO sil.iso_scopes (code, name, description)
+INSERT INTO sil.iso_scopes (code, name, description)
 VALUES 
-    ('I', 'Individual', ''),
-    ('M', 'Macrolanguage', ''),
-    ('S', 'Special', '');
+    ('I', 'Individual',     'Represents a single, distinct language'),
+    ('M', 'Macrolanguage',  'Represents a macrolanguage rather than an individual language'),
+    ('S', 'Special',        'Reserved for special purposes (e.g. undetermined)');
 
 CREATE TABLE sil.iso_types (
-    id          char(1) PRIMARY KEY,
-    name        TEXT NOT NULL,
-    description TEXT
+    id              char(1) PRIMARY KEY,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL
 );
 
-INSERT VALUES INTO sil.iso_types (code, name, description)
+INSERT INTO sil.iso_types (code, name, description)
 VALUES 
-    ('A', 'Ancient', ''),
-    ('C', 'Constructed', ''),
-    ('E', 'Extinct', ''),
-    ('H', 'Histrical', ''),
-    ('L', 'Living', ''),
-    ('S', 'Special', '');
+    ('A', 'Ancient',        'Known only from historical records'),
+    ('C', 'Constructed',    'Artificially created language'),
+    ('E', 'Extinct',        'No longer spoken'),
+    ('H', 'Histrical',      'Earlier form of a modern language'),
+    ('L', 'Living',         'Currently spoken'),
+    ('S', 'Special',        'Special-use language code');
 
 -- ============================================================================
 -- ISO 639-3 Code Language Names
@@ -70,15 +70,15 @@ CREATE TABLE sil.macrolanguages (
 );
 
 CREATE TABLE sil.macro_status (
-    id          char(1) PRIMARY KEY,
-    name        TEXT NOT NULL,
-    description TEXT
+    id              char(1) PRIMARY KEY,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL
 );
 
-INSERT VALUES INTO sil.macro_status (code, name, description)
+INSERT INTO sil.macro_status (code, name, description)
 VALUES 
-    ('A', 'Active', ''),
-    ('R', 'Retired', '');
+    ('A', 'Active',     'Code is currently valid'),
+    ('R', 'Retired',    'Code has been retired');
 
 -- ============================================================================
 -- ISO 639-3 Retirements (/Depracated)
@@ -101,7 +101,7 @@ CREATE TABLE sil.retirements (
 CREATE TABLE lookup.retirement_reasons (
     id              char(1) PRIMARY KEY,
     name            TEXT NOT NULL,
-    description     TEXT
+    description     TEXT NOT NULL
 )
 
 INSERT INTO sil.retirement_reasons (code, name, description)

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -81,7 +81,7 @@ VALUES
     ('R', 'Retired',    'Code has been retired');
 
 -- ============================================================================
--- ISO 639-3 Retirements (/Depracated)
+-- ISO 639-3 Retirements (A.K.A Depracated Codes)
 -- ============================================================================
 
 CREATE TABLE sil.retirements (
@@ -89,12 +89,10 @@ CREATE TABLE sil.retirements (
     iso_code            char(3)      NOT NULL,      -- The three-letter 639-3 identifier
     ref_name            varchar(150) NOT NULL,      -- reference name of language
     retired_reason      char(1)      NOT NULL,
-    changed_to          char(3)      NULL,          -- in the cases of C, D, and M, the identifier to which all instances of this Id should be changed
     retired_remedy      varchar(300) NULL,          -- The instructions for updating an instance of the retired (split) identifier
-    Effective           DATE        NOT NULL,       -- The date the retirement became effective
+    effective           DATE         NOT NULL,       -- The date the retirement became effective
     FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id),
-    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id)
 );
 
 CREATE TABLE sil.retirement_reasons (
@@ -112,3 +110,10 @@ VALUES
     -- Exists independently
     ('N', 'Non-existent',   'Language determined not to exist'),
     ('S', 'Split',          'Language split into multiple codes');
+
+CREATE TABLE sil.retirement_changes (
+    id                  SERIAL PRIMARY KEY,
+    retirement_id       INTEGER NOT NULL,
+    changed_to          char(3) NOT NULL,          -- in the cases of C, D, and M (Retirement_Reason), the identifier to which all instances of this Id should be changed
+    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id)
+)

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -5,7 +5,7 @@
 -- ============================================================================
 
 CREATE TABLE sil.iso_codes (
-    id          char(3) NOT NULL,       -- The three-letter 639-3 identifier
+    id          char(3) PRIMARY KEY,    -- The three-letter 639-3 identifier
     part2b      char(3) NULL,           -- Equivalent 639-2 identifier of the bibliographic applications (if there is one)
     part2t      char(3) NULL,           -- Equivalent 639-2 identifier of the terminology applications code (if there is one)
     part1       char(2) NULL,           -- Equivalent 639-1 identifier, (if there is one)
@@ -64,7 +64,7 @@ CREATE TABLE sil.macrolanguages (
     macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
     iso_id              char(3) NOT NULL,   -- The identifier for an individual language that is a member of the macrolanguage
     iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
-    PRIMARY KEY (macro_id, iso_id)
+    PRIMARY KEY (macro_id, iso_id),
     FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (iso_status) REFERENCES sil.macro_status (id)
 );
@@ -97,7 +97,7 @@ CREATE TABLE sil.retirements (
     FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id)
 );
 
-CREATE TABLE lookup.retirement_reasons (
+CREATE TABLE sil.retirement_reasons (
     id              char(1) PRIMARY KEY,
     name            TEXT NOT NULL,
     description     TEXT NOT NULL

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -4,19 +4,6 @@
 -- ISO 639-3 Codes
 -- ============================================================================
 
-CREATE TABLE sil.iso_codes (
-    id          char(3) PRIMARY KEY,    -- The three-letter 639-3 identifier
-    part2b      char(3) NULL,           -- Equivalent 639-2 identifier of the bibliographic applications (if there is one)
-    part2t      char(3) NULL,           -- Equivalent 639-2 identifier of the terminology applications code (if there is one)
-    part1       char(2) NULL,           -- Equivalent 639-1 identifier, (if there is one)
-    scope       char(1) NOT NULL, 
-    type        char(1) NOT NULL,
-    ref_name    varchar(150) NOT NULL,  -- Reference language name 
-    comment     varchar(150) NULL,      -- Comment relating to one or more of the columns
-    FOREIGN KEY (scope) REFERENCES sil.iso_scopes (id),
-    FOREIGN KEY (type) REFERENCES sil.iso_types (id)
-);
-
 CREATE TABLE sil.iso_scopes (
     id              char(1) PRIMARY KEY,
     name            TEXT NOT NULL,
@@ -44,6 +31,19 @@ VALUES
     ('L', 'Living',         'Currently spoken'),
     ('S', 'Special',        'Special-use language code');
 
+CREATE TABLE sil.iso_codes (
+    id          char(3) PRIMARY KEY,    -- The three-letter 639-3 identifier
+    part2b      char(3) NULL,           -- Equivalent 639-2 identifier of the bibliographic applications (if there is one)
+    part2t      char(3) NULL,           -- Equivalent 639-2 identifier of the terminology applications code (if there is one)
+    part1       char(2) NULL,           -- Equivalent 639-1 identifier, (if there is one)
+    scope       char(1) NOT NULL, 
+    type        char(1) NOT NULL,
+    ref_name    varchar(150) NOT NULL,  -- Reference language name 
+    comment     varchar(150) NULL,      -- Comment relating to one or more of the columns
+    FOREIGN KEY (scope) REFERENCES sil.iso_scopes (id),
+    FOREIGN KEY (type) REFERENCES sil.iso_types (id)
+);
+
 -- ============================================================================
 -- ISO 639-3 Code Language Names
 -- ============================================================================
@@ -60,15 +60,6 @@ CREATE TABLE sil.iso_names (
 -- ISO 639-3 Macrolanguage Codes
 -- ============================================================================
 
-CREATE TABLE sil.macrolanguages (
-    macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
-    iso_id              char(3) NOT NULL,   -- The identifier for an individual language that is a member of the macrolanguage
-    iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
-    PRIMARY KEY (macro_id, iso_id),
-    FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
-    FOREIGN KEY (iso_status) REFERENCES sil.macro_status (id)
-);
-
 CREATE TABLE sil.macro_status (
     id              char(1) PRIMARY KEY,
     name            TEXT NOT NULL,
@@ -80,20 +71,18 @@ VALUES
     ('A', 'Active',     'Code is currently valid'),
     ('R', 'Retired',    'Code has been retired');
 
+CREATE TABLE sil.macrolanguages (
+    macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
+    iso_id              char(3) NOT NULL,   -- The identifier for an individual language that is a member of the macrolanguage
+    iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
+    PRIMARY KEY (macro_id, iso_id),
+    FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (iso_status) REFERENCES sil.macro_status (id)
+);
+
 -- ============================================================================
 -- ISO 639-3 Retirements (A.K.A Depracated Codes)
 -- ============================================================================
-
-CREATE TABLE sil.retirements (
-    id                  SERIAL PRIMARY KEY,
-    iso_code            char(3)      NOT NULL,      -- The three-letter 639-3 identifier
-    ref_name            varchar(150) NOT NULL,      -- reference name of language
-    retired_reason      char(1)      NOT NULL,
-    retired_remedy      varchar(300) NULL,          -- The instructions for updating an instance of the retired (split) identifier
-    effective           DATE         NOT NULL,       -- The date the retirement became effective
-    FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
-    FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id)
-);
 
 CREATE TABLE sil.retirement_reasons (
     id              char(1) PRIMARY KEY,
@@ -110,6 +99,17 @@ VALUES
     -- Exists independently
     ('N', 'Non-existent',   'Language determined not to exist'),
     ('S', 'Split',          'Language split into multiple codes');
+    
+CREATE TABLE sil.retirements (
+    id                  SERIAL PRIMARY KEY,
+    iso_code            char(3)      NOT NULL,      -- The three-letter 639-3 identifier
+    ref_name            varchar(150) NOT NULL,      -- reference name of language
+    retired_reason      char(1)      NOT NULL,
+    retired_remedy      varchar(300) NULL,          -- The instructions for updating an instance of the retired (split) identifier
+    effective           DATE         NOT NULL,       -- The date the retirement became effective
+    FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id)
+);
 
 CREATE TABLE sil.retirement_changes (
     id                  SERIAL PRIMARY KEY,

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -92,7 +92,7 @@ CREATE TABLE sil.retirements (
     retired_remedy      varchar(300) NULL,          -- The instructions for updating an instance of the retired (split) identifier
     effective           DATE         NOT NULL,       -- The date the retirement became effective
     FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
-    FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id),
+    FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id)
 );
 
 CREATE TABLE sil.retirement_reasons (
@@ -115,5 +115,6 @@ CREATE TABLE sil.retirement_changes (
     id                  SERIAL PRIMARY KEY,
     retirement_id       INTEGER NOT NULL,
     changed_to          char(3) NOT NULL,          -- in the cases of C, D, and M (Retirement_Reason), the identifier to which all instances of this Id should be changed
-    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id)
+    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (retirement_id) REFERENCES sil.retirements (id)
 )

--- a/services/ingestor/usx/files/base_file.py
+++ b/services/ingestor/usx/files/base_file.py
@@ -28,7 +28,7 @@ class BaseFile:
     # IF IT DOES, USE UPDATE INSTEAD OF INSERT?
 
 
-    def sha256_file(path: str) -> str:
+    def sha256_file(self, path: str) -> str:
         hasher = hashlib.sha256()
         with open(path, "rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):
@@ -46,7 +46,6 @@ class BaseFile:
         file_hash = self.sha256_file(file_path)
 
         # Try find matching hash
-
         matched_file = self.read.get_file_by_hash(
             content_hash    = file_hash,
             data_format     = data_format

--- a/services/ingestor/usx/ingestor.py
+++ b/services/ingestor/usx/ingestor.py
@@ -262,7 +262,7 @@ class USXIngestor:
         # Initialise logfile
         self.translation_title = f"{self.dbl_id}-{self.agreement_id}"
 
-        self.log = self.manager.create_log_in_folder(["logs", "ingestor"], f"{self.translation_title}")
+        self.log = self.manager.create_log_in_folder(["logs", "ingestor", "usx"], f"{self.translation_title}")
         self.log.set_logging_level(1) # DEBUG logging
 
         licence_code = await self.get_licence_code(page)

--- a/services/ingestor/usx/ingestor.py
+++ b/services/ingestor/usx/ingestor.py
@@ -21,7 +21,11 @@ class USXIngestor:
         all_translations: list | None = None,
     ):
         self.manager = manager or ManagerHandler()
-        self.manager.get_obj().set_default_bucket("bible-dbl-raw")
+        self.manager.obj.create_bucket(
+            bucket_name     = "bible-dbl-raw",
+            is_versioned    = True,
+            is_default      = True
+        )
 
         StrongsIngestor(self.manager)
 

--- a/services/manager/dbmanager.py
+++ b/services/manager/dbmanager.py
@@ -52,6 +52,7 @@ class DBManager:
         migrations = [
             db_server_script_path / schema_folder / "core"      / "schemas.sql",
             db_server_script_path / schema_folder / "core"      / "extensions.sql",
+            db_server_script_path / schema_folder / "sil"       / "language_codes.sql",
             db_server_script_path / schema_folder / "reference" / "licences.sql",
             db_server_script_path / schema_folder / "reference" / "sources.sql",
             db_server_script_path / schema_folder / "reference" / "files.sql",

--- a/services/manager/objectmanager.py
+++ b/services/manager/objectmanager.py
@@ -11,8 +11,7 @@ from database.boundary.base_boundary import ReadBoundary, WriteBoundary
 
 class ObjectManager:
     def __init__(self, 
-            this_manager    : "ManagerHandler"  = None, 
-            default_bucket  : str               = None
+            this_manager    : "ManagerHandler"  = None
         ):
         self.this_manager   = this_manager
         self.env            = None
@@ -40,22 +39,11 @@ class ObjectManager:
 
         # Set bucket creation to be called and done within ingestion pipeline relevant to it, 
         #       this makes sure no drift in names + can set default bucket for each pipeline
-        self.create_bucket(
-            bucket_name     = "bible-dbl-raw",
-            is_versioned    = True
-        )
-        self.create_bucket(
-            bucket_name     = "open-bible-location-data",
-        )
-        self.create_bucket(
-            bucket_name     = "bible-nlp"
-        )
-        
-        # Allow for setting default bucket
-        self.create_bucket(
-            bucket_name     = default_bucket,
-            is_default      = True
-        )
+        # self.create_bucket(
+        #     bucket_name     = "bible-dbl-raw",
+        #     is_versioned    = True,
+        #     is_default      = True
+        # )
     
     def create_bucket(self, 
             bucket_name     : str, 


### PR DESCRIPTION
# What
Created an intial database schema to make use of for SIL ISO 639-3 Data Ingestion.

# Why
As part of ticket (BIL-84) to design an initial database schema for the preperation of the ingestion of ISO 639-3 from SIL.
