### PR TITLE
feature: BIL-87 & BIL-89: SIL ISO 639-3 Language Code ingestion

### DIFF
--- a/services/app.py
+++ b/services/app.py
@@ -90,6 +90,7 @@ if __name__ == "__main__":
         # restart_docker("memgraph")
         initialise_script("init_labelstudio.py", 60) # Label Studio has a long delay before operational
         # # start_api_server() 
+        run_script("ingestor.sil.ingestor")
         run_script("ingestor.usx.ingestor")
         # create_database_backup()
         # run_script(".\labeller\labeller.py")

--- a/services/database/boundary/base_boundary.py
+++ b/services/database/boundary/base_boundary.py
@@ -94,6 +94,25 @@ class WriteBoundary(QueryBoundary):
         ))
         return mapping_id
     
+    def persist_file(self,
+            etag            : str,
+            type            : str,
+            object_path     : str,
+            bucket          : str,
+            source_id       : int,
+            version_id      : str, 
+            data_format     : str,
+            content_hash    : str,
+            version_note    : str = None,
+        ) -> int:
+        query = """
+            INSERT INTO audit.files (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash) 
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id;
+        """
+        file_id = self.db.fetch_clean_one(query, (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash))
+        return file_id
+    
 class DeleteBoundary(QueryBoundary):
     pass
 

--- a/services/database/boundary/base_boundary.py
+++ b/services/database/boundary/base_boundary.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from manager.dbmanager import DBManager
 
+import json
+
 class QueryBoundary:
     def __init__(self, db_manager: "DBManager"):
         self.db = db_manager
@@ -62,6 +64,15 @@ class ReadBoundary(QueryBoundary):
         """
         result = self.db.fetch_all(query)
         return result
+    
+    def find_source(self, 
+            code: str
+        ) -> int:
+        query = """
+            SELECT id FROM audit.sources WHERE code=%s
+        """
+        source_id = self.db.fetch_clean_one(query, (code,))
+        return source_id
 
 class WriteBoundary(QueryBoundary):
     def persist_label_studio_project(self,
@@ -112,6 +123,64 @@ class WriteBoundary(QueryBoundary):
         """
         file_id = self.db.fetch_clean_one(query, (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash))
         return file_id
+    
+    def init_source(self,
+            source_type: str,
+            url: str
+        ):
+        query = """
+            INSERT INTO audit.sources(source_type, url)
+            VALUES (%s, %s)
+            RETURNING id;
+        """
+        source_id = self.db.execute(query, (source_type, url))
+        return source_id
+    
+    def update_source(self,
+            code: str,
+            name: str,
+            description: str,
+            version: str, 
+            note: str,
+            parent_source: str,
+            official_citation: str = None,
+            date_published: str = None,
+            metadata: json = None
+        ):
+        query = """
+            UPDATE audit.sources
+            SET code = %s,
+                name = %s,
+                description = %s,
+                version = %s,
+                note = %s,
+                official_citation = %s,
+                date_published = %s,
+                metadata = %s,
+            WHERE id = %s
+        """
+        self.db.fetch_clean_one(query, (code, name, description, version, note, parent_source, official_citation, date_published, metadata))
+
+    def persist_source(self,
+            source_type: str,
+            code: str,
+            name: str,
+            description: str,
+            version: str,
+            url: str,    
+            note: str,
+            parent_source: str,
+            official_citation: str = None,
+            date_published: str = None,
+            metadata: json = None
+        ) -> int:
+        query = """
+            INSERT INTO audit.sources (source_type, code, name, description, version, url, note, parent_source, official_citation, date_published, metadata) 
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id;
+        """
+        source_id = self.db.fetch_clean_one(query, (source_type, code, name, description, version, url, note, parent_source, official_citation, date_published, metadata))
+        return source_id
     
 class DeleteBoundary(QueryBoundary):
     pass

--- a/services/database/boundary/base_boundary.py
+++ b/services/database/boundary/base_boundary.py
@@ -308,6 +308,17 @@ class WriteBoundary(QueryBoundary):
         """
         self.db.execute(query, (licence_id, attribute_code, custom_note))
 
+    def map_all_licence_attributes(self,
+            licence_id  : int,
+            attributes  : list
+        ): 
+
+        for attribute in attributes:
+            self.persist_licence_attribute_mapping(
+                licence_id      = licence_id,
+                attribute_code  = attribute
+            )
+
 class DeleteBoundary(QueryBoundary):
     pass
 

--- a/services/database/boundary/base_boundary.py
+++ b/services/database/boundary/base_boundary.py
@@ -9,6 +9,10 @@ class QueryBoundary:
         self.db = db_manager
 
 class ReadBoundary(QueryBoundary):
+    # ============================================================================
+    #                                   FILES
+    # ============================================================================
+
     def read_file(self, 
             file_id: int
         ): 
@@ -56,6 +60,10 @@ class ReadBoundary(QueryBoundary):
         )
         return file_id
     
+    # ============================================================================
+    #                                   LABEL STUDIO
+    # ============================================================================
+    
     def get_all_label_projects(self) -> list[tuple[int, int, str, str]]:
         query = """
             SELECT tlp.project_id, tlp.translation_id, lp.name, lp.description
@@ -65,6 +73,10 @@ class ReadBoundary(QueryBoundary):
         result = self.db.fetch_all(query)
         return result
     
+    # ============================================================================
+    #                                   SOURCE
+    # ============================================================================
+
     def find_source(self, 
             code: str
         ) -> int:
@@ -73,8 +85,37 @@ class ReadBoundary(QueryBoundary):
         """
         source_id = self.db.fetch_clean_one(query, (code,))
         return source_id
+    
+    # ============================================================================
+    #                                   LANGUAGE
+    # ============================================================================
+
+    def find_language(self, 
+            iso_code: str
+        ) -> int:
+        query = """
+            SELECT id FROM language.languages WHERE iso = %s;
+        """
+        result = self.db.fetch_clean_one(query, (iso_code,))
+        return result
+    
+    # ============================================================================
+    #                                   LICENCE
+    # ============================================================================
+
+    def find_license(self,
+            license_code: str
+        ) -> int:
+        query = """
+            SELECT id FROM audit.licences WHERE code=%s
+        """
+        licence_id = self.db.fetch_clean_one(query, (license_code, ))
+        return licence_id
 
 class WriteBoundary(QueryBoundary):
+    # ============================================================================
+    #                                   LABEL STUDIO
+    # ============================================================================
     def persist_label_studio_project(self,
             label_project_id    : int,
             project_name        : str,
@@ -105,6 +146,10 @@ class WriteBoundary(QueryBoundary):
         ))
         return mapping_id
     
+    # ============================================================================
+    #                                   FILES
+    # ============================================================================
+
     def persist_file(self,
             etag            : str,
             type            : str,
@@ -124,6 +169,10 @@ class WriteBoundary(QueryBoundary):
         file_id = self.db.fetch_clean_one(query, (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash))
         return file_id
     
+    # ============================================================================
+    #                                   SOURCES
+    # ============================================================================
+
     def init_source(self,
             source_type: str,
             url: str
@@ -182,6 +231,83 @@ class WriteBoundary(QueryBoundary):
         source_id = self.db.fetch_clean_one(query, (source_type, code, name, description, version, url, note, parent_source, official_citation, date_published, metadata))
         return source_id
     
+    # ============================================================================
+    #                                   INGESTION
+    # ============================================================================
+
+    def start_ingestion(self,
+            source_id: int,
+            start_time: str
+        ) -> int: 
+        query = """
+            INSERT INTO audit.ingestion_stats (source_id, start_time)
+            VALUES (%s, %s)
+            RETURNING id;
+        """
+        ingestion_id = self.db.fetch_clean_one(query, (source_id, start_time))
+        return ingestion_id
+
+    def end_ingestion(self,
+            ingestion_id: int,
+            end_time: str,
+            error_message: str = None
+        ) -> None:
+        query = """
+            UPDATE audit.ingestion_stats
+            SET end_time = %s,
+                error_message = %s
+            WHERE id = %s
+        """
+        self.db.execute(query, (end_time, error_message, ingestion_id))
+
+    # ============================================================================
+    #                                   LICENCES
+    # ============================================================================
+    
+    def persist_licence(self, 
+            source_id: int,
+            code: str,
+            name: str,
+            version: str,
+            link: str,
+            valid_from: str = None,
+            valid_until: str = None,
+            notes: str = None
+        ) -> int:
+        query = """
+            INSERT INTO audit.licences (source_id, code, name, version, valid_from, valid_until, notes) 
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id;
+        """
+        licence_id = self.db.fetch_clean_one(query, (source_id, code, name, version, link, valid_from, valid_until, notes))
+        return licence_id
+
+    def persist_licence_attribute(self,
+            attribute_code: str,
+            name: str,
+            description: str,
+            attribute_type: int         
+        ) -> str:
+        query = """
+            INSERT INTO audit.licence_attributes (attribute_code, name, description, attribute_type)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT DO NOTHING
+        """
+        self.db.execute(query , (attribute_code, name, description, attribute_type))
+        
+        return
+
+    def persist_licence_attribute_mapping(self,
+            licence_id: int,
+            attribute_code: str,
+            custom_note: str = None                  
+        ) -> None:
+        query = """
+            INSERT INTO audit.licence_attribute_mapping (licence_id, attribute_code, custom_note)
+            VALUES (%s, %s, %s)
+        """
+        self.db.execute(query, (licence_id, attribute_code, custom_note))
+
 class DeleteBoundary(QueryBoundary):
     pass
 

--- a/services/database/boundary/base_boundary.py
+++ b/services/database/boundary/base_boundary.py
@@ -78,7 +78,7 @@ class ReadBoundary(QueryBoundary):
     # ============================================================================
 
     def find_source(self, 
-            code: str
+            code    : str
         ) -> int:
         query = """
             SELECT id FROM audit.sources WHERE code=%s
@@ -91,7 +91,7 @@ class ReadBoundary(QueryBoundary):
     # ============================================================================
 
     def find_language(self, 
-            iso_code: str
+            iso_code    : str
         ) -> int:
         query = """
             SELECT id FROM language.languages WHERE iso = %s;
@@ -104,7 +104,7 @@ class ReadBoundary(QueryBoundary):
     # ============================================================================
 
     def find_license(self,
-            license_code: str
+            license_code    : str
         ) -> int:
         query = """
             SELECT id FROM audit.licences WHERE code=%s
@@ -174,8 +174,8 @@ class WriteBoundary(QueryBoundary):
     # ============================================================================
 
     def init_source(self,
-            source_type: str,
-            url: str
+            source_type     : str,
+            url             : str
         ):
         query = """
             INSERT INTO audit.sources(source_type, url)
@@ -186,15 +186,15 @@ class WriteBoundary(QueryBoundary):
         return source_id
     
     def update_source(self,
-            code: str,
-            name: str,
-            description: str,
-            version: str, 
-            note: str,
-            parent_source: str,
-            official_citation: str = None,
-            date_published: str = None,
-            metadata: json = None
+            code                : str,
+            name                : str,
+            description         : str,
+            version             : str, 
+            note                : str,
+            parent_source       : str,
+            official_citation   : str = None,
+            date_published      : str = None,
+            metadata            : json = None
         ):
         query = """
             UPDATE audit.sources
@@ -211,17 +211,17 @@ class WriteBoundary(QueryBoundary):
         self.db.fetch_clean_one(query, (code, name, description, version, note, parent_source, official_citation, date_published, metadata))
 
     def persist_source(self,
-            source_type: str,
-            code: str,
-            name: str,
-            description: str,
-            version: str,
-            url: str,    
-            note: str,
-            parent_source: str,
-            official_citation: str = None,
-            date_published: str = None,
-            metadata: json = None
+            source_type         : str,
+            code                : str,
+            name                : str,
+            description         : str,
+            version             : str,
+            url                 : str,    
+            note                : str,
+            parent_source       : str,
+            official_citation   : str = None,
+            date_published      : str = None,
+            metadata            : json = None
         ) -> int:
         query = """
             INSERT INTO audit.sources (source_type, code, name, description, version, url, note, parent_source, official_citation, date_published, metadata) 
@@ -236,8 +236,8 @@ class WriteBoundary(QueryBoundary):
     # ============================================================================
 
     def start_ingestion(self,
-            source_id: int,
-            start_time: str
+            source_id   : int,
+            start_time  : str
         ) -> int: 
         query = """
             INSERT INTO audit.ingestion_stats (source_id, start_time)
@@ -248,9 +248,9 @@ class WriteBoundary(QueryBoundary):
         return ingestion_id
 
     def end_ingestion(self,
-            ingestion_id: int,
-            end_time: str,
-            error_message: str = None
+            ingestion_id    : int,
+            end_time        : str,
+            error_message   : str = None
         ) -> None:
         query = """
             UPDATE audit.ingestion_stats
@@ -265,14 +265,14 @@ class WriteBoundary(QueryBoundary):
     # ============================================================================
     
     def persist_licence(self, 
-            source_id: int,
-            code: str,
-            name: str,
-            version: str,
-            link: str,
-            valid_from: str = None,
-            valid_until: str = None,
-            notes: str = None
+            source_id       : int,
+            code            : str,
+            name            : str,
+            version         : str,
+            link            : str,
+            valid_from      : str = None,
+            valid_until     : str = None,
+            notes           : str = None
         ) -> int:
         query = """
             INSERT INTO audit.licences (source_id, code, name, version, valid_from, valid_until, notes) 
@@ -283,10 +283,10 @@ class WriteBoundary(QueryBoundary):
         return licence_id
 
     def persist_licence_attribute(self,
-            attribute_code: str,
-            name: str,
-            description: str,
-            attribute_type: int         
+            attribute_code  : str,
+            name            : str,
+            description     : str,
+            attribute_type  : int         
         ) -> str:
         query = """
             INSERT INTO audit.licence_attributes (attribute_code, name, description, attribute_type)
@@ -298,9 +298,9 @@ class WriteBoundary(QueryBoundary):
         return
 
     def persist_licence_attribute_mapping(self,
-            licence_id: int,
-            attribute_code: str,
-            custom_note: str = None                  
+            licence_id      : int,
+            attribute_code  : str,
+            custom_note     : str = None                  
         ) -> None:
         query = """
             INSERT INTO audit.licence_attribute_mapping (licence_id, attribute_code, custom_note)

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -4,7 +4,7 @@ class SILReadBoundary(ReadBoundary):
     # figure out whether iso code is present in the database
     def is_iso_code(self,
             iso_code    : str            
-        ):
+        ) -> bool:
         query = """
             SELECT * FROM sil.iso_codes WHERE id = %s;
         """
@@ -13,7 +13,7 @@ class SILReadBoundary(ReadBoundary):
     
     def get_retirement(self,
             iso_code    : str            
-        ):
+        ) -> int:
         query = """
             SELECT id FROM sil.retirements WHERE iso_code = %s;
         """

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -20,13 +20,14 @@ class SILWriteBoundary(WriteBoundary):
             scope           : str,
             type            : str,
             ref_name        : str,
+            status          : str,
             comment         : str
         ) -> None:
         query = """
-            INSERT INTO sil.iso_codes (id, part2b, part2t, part1, scope, type, ref_name, comment)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO sil.iso_codes (id, part2b, part2t, part1, scope, type, ref_name, comment, status)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
         """
-        self.db.execute(query, (iso_code, part2b, part2t, part1, scope, type, ref_name, comment))
+        self.db.execute(query, (iso_code, part2b, part2t, part1, scope, type, ref_name, comment, status))
 
     def persist_iso_names(self,
             iso_code        : str,

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -1,7 +1,15 @@
 from database.boundary.base_boundary import ReadBoundary, WriteBoundary, DeleteBoundary
 
 class SILReadBoundary(ReadBoundary):
-    pass
+    # figure out whether iso code is present in the database
+    def is_iso_code(self,
+            iso_code    : str            
+        ):
+        query = """
+            SELECT * FROM sil.iso_codes WHERE id = %s;
+        """
+        result = self.db.fetch_one(query, (iso_code, ))
+        return True if result else False
 
 class SILWriteBoundary(WriteBoundary):
     def persist_iso_code(self,

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -53,8 +53,9 @@ class SILWriteBoundary(WriteBoundary):
         query = """
             INSERT INTO sil.retirements (iso_code, ref_name, retired_reason, retired_remedy, effective)
             VALUES (%s, %s, %s, %s, %s)
+            RETURNING id;
         """
-        retirement_id = self.db.execute(query, (iso_code, ref_name, retired_reason, retired_remedy, effective))
+        retirement_id = self.db.fetch_clean_one(query, (iso_code, ref_name, retired_reason, retired_remedy, effective))
         return retirement_id
 
     def persist_iso_retirement_changes(self,

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -1,0 +1,10 @@
+from database.boundary.base_boundary import ReadBoundary, WriteBoundary, DeleteBoundary
+
+class SILReadBoundary(ReadBoundary):
+    pass
+
+class SILWriteBoundary(WriteBoundary):
+    pass
+
+class SILDeleteBoundary(DeleteBoundary):
+    pass

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -4,7 +4,68 @@ class SILReadBoundary(ReadBoundary):
     pass
 
 class SILWriteBoundary(WriteBoundary):
-    pass
+    def persist_iso_code(self,
+            iso_code        : str,
+            part2b          : str,
+            part2t          : str,
+            part1           : str,
+            scope           : str,
+            type            : str,
+            ref_name        : str,
+            comment         : str
+        ) -> None:
+        query = """
+            INSERT INTO sil.iso_codes (id, part2b, part2t, part1, scope, type, ref_name, comment)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """
+        self.db.execute(query, (iso_code, part2b, part2t, part1, scope, type, ref_name, comment))
+
+    def persist_iso_names(self,
+            iso_code        : str,
+            print_name      : str,
+            inverted_name   : str
+        ) -> None:
+
+        query = """
+            INSERT INTO sil.iso_names (iso_code, print_name, inverted_name)
+            VALUES (%s, %s, %s)
+        """
+        self.db.execute(query, (iso_code, print_name, inverted_name))
+
+    def persist_iso_macrolanguage(self,
+            macro_id    : str,
+            iso_id      : str,
+            iso_status  : str
+        ) -> None:
+        query = """
+            INSERT INTO sil.macrolanguages (macro_id, iso_id, iso_status)
+            VALUES (%s, %s, %s)
+        """
+        self.db.execute(query, (macro_id, iso_id, iso_status))
+
+    def persist_iso_retirements(self,
+            iso_code        : str,
+            ref_name        : str,
+            retired_reason  : str,
+            retired_remedy  : str,
+            effective       : str
+        ) -> int:
+        query = """
+            INSERT INTO sil.retirements (iso_code, ref_name, retired_reason, retired_remedy, effective)
+            VALUES (%s, %s, %s, %s, %s)
+        """
+        retirement_id = self.db.execute(query, (iso_code, ref_name, retired_reason, retired_remedy, effective))
+        return retirement_id
+
+    def persist_iso_retirement_changes(self,
+            retirement_id   : int,
+            changed_to      : str
+        ) -> None:
+        query = """
+            INSERT INTO sil.retirement_changes (retirement_id, changed_to)
+            VALUES (%s, %s)
+        """
+        self.db.execute(query, (retirement_id, changed_to))
 
 class SILDeleteBoundary(DeleteBoundary):
     pass

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -29,14 +29,13 @@ class SILWriteBoundary(WriteBoundary):
             scope           : str,
             type            : str,
             ref_name        : str,
-            status          : str,
             comment         : str
         ) -> None:
         query = """
-            INSERT INTO sil.iso_codes (id, part2b, part2t, part1, scope, type, ref_name, comment, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO sil.iso_codes (id, part2b, part2t, part1, scope, type, ref_name, comment)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         """
-        self.db.execute(query, (iso_code, part2b, part2t, part1, scope, type, ref_name, comment, status))
+        self.db.execute(query, (iso_code, part2b, part2t, part1, scope, type, ref_name, comment))
 
     def persist_iso_names(self,
             iso_code        : str,
@@ -51,15 +50,16 @@ class SILWriteBoundary(WriteBoundary):
         self.db.execute(query, (iso_code, print_name, inverted_name))
 
     def persist_iso_macrolanguage(self,
-            macro_id    : str,
-            iso_id      : str,
-            iso_status  : str
+            macro_id        : str,
+            iso_id          : str,
+            retirement_id   : int,
+            iso_status      : str
         ) -> None:
         query = """
-            INSERT INTO sil.macrolanguages (macro_id, iso_id, iso_status)
-            VALUES (%s, %s, %s)
+            INSERT INTO sil.macrolanguages (macro_id, iso_id, iso_status, retirement_id)
+            VALUES (%s, %s, %s, %s)
         """
-        self.db.execute(query, (macro_id, iso_id, iso_status))
+        self.db.execute(query, (macro_id, iso_id, iso_status, retirement_id))
 
     def persist_iso_retirements(self,
             iso_code        : str,

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -10,6 +10,15 @@ class SILReadBoundary(ReadBoundary):
         """
         result = self.db.fetch_one(query, (iso_code, ))
         return True if result else False
+    
+    def get_retirement(self,
+            iso_code    : str            
+        ):
+        query = """
+            SELECT id FROM sil.retirements WHERE iso_code = %s;
+        """
+        retirement_id = self.db.fetch_one(query, (iso_code, ))
+        return retirement_id
 
 class SILWriteBoundary(WriteBoundary):
     def persist_iso_code(self,

--- a/services/database/boundary/sil_boundary.py
+++ b/services/database/boundary/sil_boundary.py
@@ -51,8 +51,8 @@ class SILWriteBoundary(WriteBoundary):
 
     def persist_iso_macrolanguage(self,
             macro_id        : str,
-            iso_id          : str,
-            retirement_id   : int,
+            iso_id          : str | None,
+            retirement_id   : int | None,
             iso_status      : str
         ) -> None:
         query = """
@@ -77,14 +77,15 @@ class SILWriteBoundary(WriteBoundary):
         return retirement_id
 
     def persist_iso_retirement_changes(self,
-            retirement_id   : int,
-            changed_to      : str
+            from_retirement     : int,
+            to_iso_code         : str | None,
+            to_retirement       : int | None
         ) -> None:
         query = """
-            INSERT INTO sil.retirement_changes (retirement_id, changed_to)
-            VALUES (%s, %s)
+            INSERT INTO sil.retirement_changes (from_retirement, to_iso_code, to_retirement)
+            VALUES (%s, %s, %s)
         """
-        self.db.execute(query, (retirement_id, changed_to))
+        self.db.execute(query, (from_retirement, to_iso_code, to_retirement))
 
 class SILDeleteBoundary(DeleteBoundary):
     pass

--- a/services/database/boundary/usx_boundary.py
+++ b/services/database/boundary/usx_boundary.py
@@ -384,25 +384,6 @@ class USXWriteBoundary(WriteBoundary):
         """
         book_map_id = self.db.fetch_clean_one(query, (book_code, translation_id, file_id, short, long))
         return book_map_id
-
-    def persist_file(self,
-            etag            : str,
-            type            : str,
-            object_path     : str,
-            bucket          : str,
-            source_id       : int,
-            version_id      : str, 
-            data_format     : str,
-            content_hash    : str,
-            version_note    : str = None,
-        ) -> int:
-        query = """
-            INSERT INTO audit.files (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash) 
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-            RETURNING id;
-        """
-        file_id = self.db.fetch_clean_one(query, (etag, type, object_path, bucket, source_id, version_id, version_note, data_format, content_hash))
-        return file_id
     
     def persist_style_property(self,
             name: str,

--- a/services/database/boundary/usx_boundary.py
+++ b/services/database/boundary/usx_boundary.py
@@ -118,15 +118,6 @@ class USXReadBoundary(ReadBoundary):
         """
         row = self.db.fetch_one(query, (dbl_id, revision))
         return row
-
-    def find_source(self, 
-            code: str
-        ) -> int:
-        query = """
-            SELECT id FROM audit.sources WHERE code=%s
-        """
-        source_id = self.db.fetch_clean_one(query, (code,))
-        return source_id
     
     def find_agreement(self,
             agreement_id: int
@@ -245,67 +236,6 @@ class USXWriteBoundary(WriteBoundary):
         """
         paragraph_id = self.db.fetch_clean_one(query, (paragraph_node_id, style_id, parent_para_id, is_versetext))
         return paragraph_id
-    
-    def init_source(self,
-            source_type: str,
-            url: str
-        ):
-        query = """
-            INSERT INTO audit.sources(source_type, url)
-            VALUES (%s, %s)
-            RETURNING id;
-        """
-        source_id = self.db.execute(query, (source_type, url))
-        return source_id
-    
-    def update_source(self,
-            code: str,
-            name: str,
-            description: str,
-            version: str, 
-            note: str,
-            parent_source: str,
-            official_citation: str = None,
-            date_published: str = None,
-            metadata: json = None
-        ):
-        query = """
-            UPDATE audit.sources
-            SET code = %s,
-                name = %s,
-                description = %s,
-                version = %s,
-                note = %s,
-                official_citation = %s,
-                date_published = %s,
-                metadata = %s,
-            WHERE id = %s
-        """
-        self.db.fetch_clean_one(query, (code, name, description, version, note, parent_source, official_citation, date_published, metadata))
-    
-    def persist_source(self,
-            source_type: str,
-            code: str,
-            name: str,
-            description: str,
-            version: str,
-            url: str,    
-            note: str,
-            parent_source: str,
-            official_citation: str = None,
-            date_published: str = None,
-            metadata: json = None
-        ) -> int:
-        query = """
-            INSERT INTO audit.sources (source_type, code, name, description, version, url, note, parent_source, official_citation, date_published, metadata) 
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-            RETURNING id;
-        """
-        source_id = self.db.fetch_clean_one(query, (source_type, code, name, description, version, url, note, parent_source, official_citation, date_published, metadata))
-        return source_id
-    
-    def persist_language(self): # To be moved to Language Ingestor
-        pass
 
     def persist_usx_translation(self,
             dbl_id: str,

--- a/services/database/boundary/usx_boundary.py
+++ b/services/database/boundary/usx_boundary.py
@@ -22,6 +22,10 @@ class USXReadBoundary(ReadBoundary):
     # FIND      = Specific item
     # CHECK     = Only get certain subset of data
 
+    # ============================================================================
+    #                                   CHAPTERS
+    # ============================================================================
+
     def get_all_chapters(self, 
             book_code: str
         ) -> list[str]:
@@ -43,6 +47,10 @@ class USXReadBoundary(ReadBoundary):
         result = self.db.fetch_clean_one(query, (chapter_ref,))
         return result
     
+    # ============================================================================
+    #                                   BOOK
+    # ============================================================================
+    
     def find_book(self, 
             book_code: str
         ) -> int:
@@ -51,6 +59,10 @@ class USXReadBoundary(ReadBoundary):
         """
         result = self.db.fetch_clean_one(query, (book_code,))
         return result
+    
+    # ============================================================================
+    #                                   VERSE
+    # ============================================================================
     
     def find_verse(self,
             verse_ref: str
@@ -61,6 +73,10 @@ class USXReadBoundary(ReadBoundary):
         result = self.db.fetch_clean_one(query, (verse_ref,))
         return result
     
+    # ============================================================================
+    #                                   TRANSLATION
+    # ============================================================================
+
     def find_translation(self,
             dbl_id: int,
             revision: int
@@ -69,38 +85,6 @@ class USXReadBoundary(ReadBoundary):
             SELECT id FROM bible.translations WHERE dbl_id = %s AND revision = %s;
         """
         result = self.db.fetch_clean_one(query, (dbl_id, revision))
-        return result
-    
-    def get_node_count(self) -> int:
-        query = """
-            SELECT COALESCE(MAX(id), 0) FROM bible.nodes;
-        """
-        result = self.db.fetch_clean_one(query)
-        return result
-    
-    def check_para_is_versetext(self, 
-            style: str, style_file_id: int
-        ) -> bool:
-        query = """
-            SELECT versetext FROM bible.styles WHERE style = %s AND source_file_id = %s;
-        """
-        result = self.db.fetch_clean_one(query, (style, style_file_id))
-        return result
-    
-    # def get_source(self) -> int:
-    #     query = """
-    #         SELECT id FROM audit.sources WHERE source_name = 'USX';
-    #     """
-    #     result = self.db.fetch_clean_one(query)
-    #     return result
-
-    def find_language(self, 
-            iso_code: str
-        ) -> int:
-        query = """
-            SELECT id FROM language.languages WHERE iso = %s;
-        """
-        result = self.db.fetch_clean_one(query, (iso_code,))
         return result
     
     # Still need to figure out how this will work, with new split between dbl-agreements and translations
@@ -119,6 +103,40 @@ class USXReadBoundary(ReadBoundary):
         row = self.db.fetch_one(query, (dbl_id, revision))
         return row
     
+    # ============================================================================
+    #                                   NODES
+    # ============================================================================
+
+    def get_node_count(self) -> int:
+        query = """
+            SELECT COALESCE(MAX(id), 0) FROM bible.nodes;
+        """
+        node_count = self.db.fetch_clean_one(query)
+        return node_count
+    
+    # ============================================================================
+    #                                   PARAGRAPH
+    # ============================================================================
+
+    def is_paragraph_versetext(self,
+            style: str,
+            style_file_id: int
+        ) -> bool:
+        query = """
+            SELECT versetext FROM bible.styles WHERE style = %s AND source_file_id = %s
+        """
+        result = self.db.fetch_clean_one(query, (style, style_file_id))
+        
+        if result == "true": 
+            return True
+        
+        # if result == "false" or result is None:
+        return False
+    
+    # ============================================================================
+    #                                   AGREEMENT
+    # ============================================================================
+
     def find_agreement(self,
             agreement_id: int
         ) -> AgreementRecord | None:
@@ -144,38 +162,11 @@ class USXReadBoundary(ReadBoundary):
         result = self.db.fetch_one(query, (agreement_id,))
         return True if result else False
 
-    def find_license(self,
-            license_code: str
-        ) -> int:
-        query = """
-            SELECT id FROM audit.licences WHERE code=%s
-        """
-        licence_id = self.db.fetch_clean_one(query, (license_code, ))
-        return licence_id
-    
-    def get_node_count(self):
-        query = """
-            SELECT COALESCE(MAX(id), 0) FROM bible.nodes;
-        """
-        node_count = self.db.fetch_clean_one(query)
-        return node_count
-    
-    def is_paragraph_versetext(self,
-            style: str,
-            style_file_id: int
-        ) -> bool:
-        query = """
-            SELECT versetext FROM bible.styles WHERE style = %s AND source_file_id = %s
-        """
-        result = self.db.fetch_clean_one(query, (style, style_file_id))
-        
-        if result == "true": 
-            return True
-        
-        # if result == "false" or result is None:
-        return False
-
 class USXWriteBoundary(WriteBoundary):
+    # ============================================================================
+    #                                   CHAPTER
+    # ============================================================================
+
     def persist_chapter_occurence(self, 
             chapter_ref:str, book_map_id: int, translation_id: int, start_node: int=None, end_node: int=None
         ) -> int:
@@ -199,6 +190,10 @@ class USXWriteBoundary(WriteBoundary):
         """ # ON CONFLICT (chapter_ref) DO NOTHING;
         self.db.execute(query, (book_code, chapter_num, chapter_ref, is_standard))
 
+    # ============================================================================
+    #                                   TRANSLATION
+    # ============================================================================
+
     def persist_translation_info(self,
             dbl_id: str,
             revision: int,
@@ -213,29 +208,6 @@ class USXWriteBoundary(WriteBoundary):
             ON CONFLICT (dbl_id, revision) DO NOTHING;
         """
         self.db.execute(query, (dbl_id, revision, is_supported, is_test_import, reason_not_supported))
-
-    def persist_nodes(self, 
-            new_nodes: list[tuple]
-        ) -> None:
-        query = """
-            INSERT INTO bible.nodes (node_text, node_type, code, sid, eid, vid, style, number, caller, closed, version, strong, loc, parent_node_id, index_in_parent, book_map_id, canonical_path, align, translation_id, is_tokenisable) 
-            VALUES %s;
-        """
-        self.db.bulk_insert(query, new_nodes)
-
-    def persist_paragraph(self, 
-            paragraph_node_id: int, 
-            style_id: int, 
-            is_versetext: bool,
-            parent_para_id: int = None
-        ) -> int:
-        query = """
-            INSERT INTO bible.paragraphs (node_id, style_id, parent_para, is_versetext) 
-            VALUES (%s, %s, %s, %s)
-            RETURNING id;
-        """
-        paragraph_id = self.db.fetch_clean_one(query, (paragraph_node_id, style_id, parent_para_id, is_versetext))
-        return paragraph_id
 
     def persist_usx_translation(self,
             dbl_id: str,
@@ -259,6 +231,54 @@ class USXWriteBoundary(WriteBoundary):
         translation_id = self.db.fetch_clean_one(query, (dbl_id, revision, revision_note, revision_date, language_id, medium, name, name_local, abbreviation, abbreviationLocal, copyright, promotion))
         return translation_id
     
+    def persist_translation_relation(self,
+            from_dbl_id: int,
+            from_revision: int,
+            to_dbl_id: str,
+            to_revision: str,
+            relation_type: str
+        ) -> None:
+        query = """
+            INSERT INTO bible.translationrelationships (from_translation, from_revision, to_translation, to_revision, type) 
+            VALUES (%s, %s, %s, %s, %s)
+        """
+        self.db.execute(query, (from_dbl_id, from_revision, to_dbl_id, to_revision, relation_type))
+
+    # ============================================================================
+    #                                   NODES
+    # ============================================================================
+
+    def persist_nodes(self, 
+            new_nodes: list[tuple]
+        ) -> None:
+        query = """
+            INSERT INTO bible.nodes (node_text, node_type, code, sid, eid, vid, style, number, caller, closed, version, strong, loc, parent_node_id, index_in_parent, book_map_id, canonical_path, align, translation_id, is_tokenisable) 
+            VALUES %s;
+        """
+        self.db.bulk_insert(query, new_nodes)
+
+    # ============================================================================
+    #                                   PARAGRAPH
+    # ============================================================================
+
+    def persist_paragraph(self, 
+            paragraph_node_id: int, 
+            style_id: int, 
+            is_versetext: bool,
+            parent_para_id: int = None
+        ) -> int:
+        query = """
+            INSERT INTO bible.paragraphs (node_id, style_id, parent_para, is_versetext) 
+            VALUES (%s, %s, %s, %s)
+            RETURNING id;
+        """
+        paragraph_id = self.db.fetch_clean_one(query, (paragraph_node_id, style_id, parent_para_id, is_versetext))
+        return paragraph_id
+    
+    # ============================================================================
+    #                                   AGREEMENT
+    # ============================================================================
+
     def persit_dbl_agreement(self,
             dbl_id: str,
             agreement_id: int,
@@ -275,150 +295,6 @@ class USXWriteBoundary(WriteBoundary):
         """
         dbl_agreement_id = self.db.fetch_clean_one(query, (dbl_id, agreement_id, license_id, dateLicensed, dateLicenceExpires, file_id, active))
         return dbl_agreement_id
-
-    def persist_translation_file(self,
-            file_id: int,
-            translation_id: int,
-            type: str,
-            version: str
-        ) -> None:
-        query = """
-            INSERT INTO bible.translation_files (file_id, translation_id, type, version) 
-            VALUES (%s, %s, %s, %s)
-        """
-        self.db.execute(query, (file_id, translation_id, type, version))
-
-    def persist_translation_relation(self,
-            from_dbl_id: int,
-            from_revision: int,
-            to_dbl_id: str,
-            to_revision: str,
-            relation_type: str
-        ) -> None:
-        query = """
-            INSERT INTO bible.translationrelationships (from_translation, from_revision, to_translation, to_revision, type) 
-            VALUES (%s, %s, %s, %s, %s)
-        """
-        self.db.execute(query, (from_dbl_id, from_revision, to_dbl_id, to_revision, relation_type))
-
-    def persist_book_file(self,
-            book_code: str,
-            translation_id: int,
-            file_id: int,
-            short: str,
-            long: str
-        ) -> int:
-        query = """
-            INSERT INTO bible.booktofile (book_code, translation_id, file_id, short, long) 
-            VALUES (%s, %s, %s, %s, %s) RETURNING id;
-        """
-        book_map_id = self.db.fetch_clean_one(query, (book_code, translation_id, file_id, short, long))
-        return book_map_id
-    
-    def persist_style_property(self,
-            name: str,
-            value: str,
-            unit: str = None,
-            style_id: int = None
-        ) -> None:
-        query = """
-            INSERT INTO bible.properties (name, value, unit, style_id) 
-            VALUES (%s, %s, %s, %s);
-        """
-        self.db.execute(query, (name, value, unit, style_id))
-    
-    def persist_style(self,
-            style: str,
-            name: str,
-            description: str,
-            is_versetext: bool,
-            is_publishable: bool,
-            source_file_id: int
-        ) -> int:
-        query = """
-            INSERT INTO bible.styles (style, name, description, versetext, publishable, source_file_id) 
-            VALUES (%s, %s, %s, %s, %s, %s)
-            RETURNING id;
-        """
-        style_id = self.db.fetch_clean_one(query, (style, name, description, is_versetext, is_publishable, source_file_id))
-        return style_id
-    
-    def persist_excluded_verse(self,
-            verse_ref: str,
-            translation_id: int
-        ) -> None:
-        query = """
-            INSERT INTO bible.excludedverses (verse_ref, translation_id) 
-            VALUES (%s, %s);
-        """
-        self.db.execute(query, (verse_ref, translation_id))
-
-    def persist_verse(self,
-            chapter_ref: str,
-            verse_ref: str,
-            verse: str,
-            is_standard: bool
-        ) -> int:
-        query = """
-            INSERT INTO bible.verses (chapter_ref, verse_ref, verse, standard) 
-            VALUES (%s, %s, %s, %s)
-        """
-        verse_id = self.db.execute(query, (chapter_ref, verse_ref, verse, is_standard))
-        return verse_id
-    
-    def persist_footnote(self,
-            node_id: int,
-            chapter_ref: str,
-            verse_ref: str
-        ) -> int:
-        query = """
-            INSERT INTO bible.translationfootnotes (node_id, chapter_ref, verse_ref) 
-            VALUES (%s, %s, %s)
-            RETURNING id;
-        """
-        footnote_id = self.db.fetch_clean_one(query, (node_id, chapter_ref, verse_ref))
-        return footnote_id
-    
-    def persist_cross_reference(self,
-            node_id: int,
-            from_verse_ref: str,
-            to_verse_ref: str,
-            from_chapter_ref: str,
-            to_chapter_ref: str
-        ) -> int:
-        query = """
-            INSERT INTO bible.translationrefnotes (node_id, from_verse_ref, to_verse_ref, from_chapter_ref, to_chapter_ref) 
-            VALUES %s
-            RETURNING id;
-        """
-        cross_reference_id = self.db.fetch_clean_one(query, (node_id, from_verse_ref, to_verse_ref, from_chapter_ref, to_chapter_ref))
-        return cross_reference_id
-    
-    def persist_verse_correction(self,
-            non_standard_verse_ref: str,
-            verse_ref: str
-        ) -> None:
-        query = """
-            INSERT INTO bible.verse_correction (non_standard_verse_ref, verse_ref) 
-            VALUES (%s, %s)
-        """
-        self.db.execute(query, (non_standard_verse_ref, verse_ref))
-    
-    def persist_verse_occurence(self,
-            chapter_id: int,
-            book_map_id: int,
-            translation_id: int,
-            verse_ref: str,
-            start_node: int,
-            end_node: int
-        ) -> int:
-        query = """
-            INSERT INTO bible.verseoccurences (chapter_id, book_map_id, translation_id, verse_ref, start_node, end_node) 
-            VALUES (%s, %s, %s, %s, %s, %s)
-            RETURNING id;
-        """
-        verse_occurence_id = self.db.fetch_clean_one(query, (chapter_id, book_map_id, translation_id, verse_ref, start_node, end_node))
-        return verse_occurence_id
     
     def init_agreement(self,
             agreement_id: int
@@ -469,76 +345,159 @@ class USXWriteBoundary(WriteBoundary):
         """
         self.db.execute(query, (agreement_id, attribute_code, attribute_value))
 
-    def persist_licence(self, 
-            source_id: int,
-            code: str,
-            name: str,
-            version: str,
-            link: str,
-            valid_from: str = None,
-            valid_until: str = None,
-            notes: str = None
+    # ============================================================================
+    #                                   FILES
+    # ============================================================================
+
+    def persist_translation_file(self,
+            file_id: int,
+            translation_id: int,
+            type: str,
+            version: str
+        ) -> None:
+        query = """
+            INSERT INTO bible.translation_files (file_id, translation_id, type, version) 
+            VALUES (%s, %s, %s, %s)
+        """
+        self.db.execute(query, (file_id, translation_id, type, version))
+
+    
+    def persist_book_file(self,
+            book_code: str,
+            translation_id: int,
+            file_id: int,
+            short: str,
+            long: str
         ) -> int:
         query = """
-            INSERT INTO audit.licences (source_id, code, name, version, valid_from, valid_until, notes) 
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-            RETURNING id;
+            INSERT INTO bible.booktofile (book_code, translation_id, file_id, short, long) 
+            VALUES (%s, %s, %s, %s, %s) RETURNING id;
         """
-        licence_id = self.db.fetch_clean_one(query, (source_id, code, name, version, link, valid_from, valid_until, notes))
-        return licence_id
+        book_map_id = self.db.fetch_clean_one(query, (book_code, translation_id, file_id, short, long))
+        return book_map_id
     
-    def persist_licence_attribute(self,
-            attribute_code: str,
+    # ============================================================================
+    #                                   STYLES
+    # ============================================================================
+    
+    def persist_style_property(self,
+            name: str,
+            value: str,
+            unit: str = None,
+            style_id: int = None
+        ) -> None:
+        query = """
+            INSERT INTO bible.properties (name, value, unit, style_id) 
+            VALUES (%s, %s, %s, %s);
+        """
+        self.db.execute(query, (name, value, unit, style_id))
+    
+    def persist_style(self,
+            style: str,
             name: str,
             description: str,
-            attribute_type: int         
-        ) -> str:
+            is_versetext: bool,
+            is_publishable: bool,
+            source_file_id: int
+        ) -> int:
         query = """
-            INSERT INTO audit.licence_attributes (attribute_code, name, description, attribute_type)
-            VALUES (%s, %s, %s, %s)
-            ON CONFLICT DO NOTHING
-        """
-        self.db.execute(query , (attribute_code, name, description, attribute_type))
-        
-        return
-
-    def persist_licence_attribute_mapping(self,
-            licence_id: int,
-            attribute_code: str,
-            custom_note: str = None                  
-        ) -> None:
-        query = """
-            INSERT INTO audit.licence_attribute_mapping (licence_id, attribute_code, custom_note)
-            VALUES (%s, %s, %s)
-        """
-        self.db.execute(query, (licence_id, attribute_code, custom_note))
-
-    def start_ingestion(self,
-            source_id: int,
-            start_time: str
-        ) -> int: 
-        query = """
-            INSERT INTO audit.ingestion_stats (source_id, start_time)
-            VALUES (%s, %s)
+            INSERT INTO bible.styles (style, name, description, versetext, publishable, source_file_id) 
+            VALUES (%s, %s, %s, %s, %s, %s)
             RETURNING id;
         """
-        ingestion_id = self.db.fetch_clean_one(query, (source_id, start_time))
-        return ingestion_id
+        style_id = self.db.fetch_clean_one(query, (style, name, description, is_versetext, is_publishable, source_file_id))
+        return style_id
+    
+    # ============================================================================
+    #                                   VERSE
+    # ============================================================================
 
-    def end_ingestion(self,
-            ingestion_id: int,
-            end_time: str,
-            error_message: str = None
+    def persist_excluded_verse(self,
+            verse_ref: str,
+            translation_id: int
         ) -> None:
         query = """
-            UPDATE audit.ingestion_stats
-            SET end_time = %s,
-                error_message = %s
-            WHERE id = %s
+            INSERT INTO bible.excludedverses (verse_ref, translation_id) 
+            VALUES (%s, %s);
         """
-        self.db.execute(query, (end_time, error_message, ingestion_id))
+        self.db.execute(query, (verse_ref, translation_id))
 
+    def persist_verse(self,
+            chapter_ref: str,
+            verse_ref: str,
+            verse: str,
+            is_standard: bool
+        ) -> int:
+        query = """
+            INSERT INTO bible.verses (chapter_ref, verse_ref, verse, standard) 
+            VALUES (%s, %s, %s, %s)
+        """
+        verse_id = self.db.execute(query, (chapter_ref, verse_ref, verse, is_standard))
+        return verse_id
+    
+    def persist_verse_correction(self,
+            non_standard_verse_ref: str,
+            verse_ref: str
+        ) -> None:
+        query = """
+            INSERT INTO bible.verse_correction (non_standard_verse_ref, verse_ref) 
+            VALUES (%s, %s)
+        """
+        self.db.execute(query, (non_standard_verse_ref, verse_ref))
+    
+    def persist_verse_occurence(self,
+            chapter_id: int,
+            book_map_id: int,
+            translation_id: int,
+            verse_ref: str,
+            start_node: int,
+            end_node: int
+        ) -> int:
+        query = """
+            INSERT INTO bible.verseoccurences (chapter_id, book_map_id, translation_id, verse_ref, start_node, end_node) 
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING id;
+        """
+        verse_occurence_id = self.db.fetch_clean_one(query, (chapter_id, book_map_id, translation_id, verse_ref, start_node, end_node))
+        return verse_occurence_id
+    
+    # ============================================================================
+    #                          CROSS REFERENCES + FOOTNOTES
+    # ============================================================================
+    
+    def persist_footnote(self,
+            node_id: int,
+            chapter_ref: str,
+            verse_ref: str
+        ) -> int:
+        query = """
+            INSERT INTO bible.translationfootnotes (node_id, chapter_ref, verse_ref) 
+            VALUES (%s, %s, %s)
+            RETURNING id;
+        """
+        footnote_id = self.db.fetch_clean_one(query, (node_id, chapter_ref, verse_ref))
+        return footnote_id
+    
+    def persist_cross_reference(self,
+            node_id: int,
+            from_verse_ref: str,
+            to_verse_ref: str,
+            from_chapter_ref: str,
+            to_chapter_ref: str
+        ) -> int:
+        query = """
+            INSERT INTO bible.translationrefnotes (node_id, from_verse_ref, to_verse_ref, from_chapter_ref, to_chapter_ref) 
+            VALUES %s
+            RETURNING id;
+        """
+        cross_reference_id = self.db.fetch_clean_one(query, (node_id, from_verse_ref, to_verse_ref, from_chapter_ref, to_chapter_ref))
+        return cross_reference_id
+    
 class USXDeleteBoundary(DeleteBoundary):
+    # ============================================================================
+    #                                   TRANSLATION
+    # ============================================================================
+
     def delete_translation(self,
             translation_id: int
         ) -> None:

--- a/services/database/boundary/usx_boundary.py
+++ b/services/database/boundary/usx_boundary.py
@@ -27,7 +27,7 @@ class USXReadBoundary(ReadBoundary):
     # ============================================================================
 
     def get_all_chapters(self, 
-            book_code: str
+            book_code   : str
         ) -> list[str]:
         if len(book_code) != 3:
             raise ValueError("Book code must be 3 characters long.")
@@ -39,7 +39,7 @@ class USXReadBoundary(ReadBoundary):
         return result
     
     def find_chapter(self, 
-            chapter_ref: str
+            chapter_ref : str
         ) -> str:
         query = """
             SELECT id FROM bible.chapters WHERE chapter_ref = %s
@@ -52,7 +52,7 @@ class USXReadBoundary(ReadBoundary):
     # ============================================================================
     
     def find_book(self, 
-            book_code: str
+            book_code   : str
         ) -> int:
         query = """
             SELECT id FROM bible.books WHERE code = %s;
@@ -65,7 +65,7 @@ class USXReadBoundary(ReadBoundary):
     # ============================================================================
     
     def find_verse(self,
-            verse_ref: str
+            verse_ref   : str
         ) -> int:
         query = """
             SELECT id FROM bible.verses WHERE verse_ref = %s;
@@ -78,8 +78,8 @@ class USXReadBoundary(ReadBoundary):
     # ============================================================================
 
     def find_translation(self,
-            dbl_id: int,
-            revision: int
+            dbl_id      : int,
+            revision    : int
         ) -> str:
         query = """
             SELECT id FROM bible.translations WHERE dbl_id = %s AND revision = %s;
@@ -89,8 +89,8 @@ class USXReadBoundary(ReadBoundary):
     
     # Still need to figure out how this will work, with new split between dbl-agreements and translations
     def is_translation_supported(self, 
-            dbl_id: str, 
-            revision: int | None = None
+            dbl_id      : str, 
+            revision    : int | None = None
         ) -> bool:
         query = """
             SELECT supported
@@ -119,8 +119,8 @@ class USXReadBoundary(ReadBoundary):
     # ============================================================================
 
     def is_paragraph_versetext(self,
-            style: str,
-            style_file_id: int
+            style           : str,
+            style_file_id   : int
         ) -> bool:
         query = """
             SELECT versetext FROM bible.styles WHERE style = %s AND source_file_id = %s
@@ -138,7 +138,7 @@ class USXReadBoundary(ReadBoundary):
     # ============================================================================
 
     def find_agreement(self,
-            agreement_id: int
+            agreement_id    : int
         ) -> AgreementRecord | None:
         query = """
             SELECT dbl_id, agreement_id, licence_file_id, base_licence_id, dateLicence, dateLicenceExpiry, notes
@@ -151,7 +151,7 @@ class USXReadBoundary(ReadBoundary):
         return AgreementRecord(*result)
 
     def find_agreement_expired(self,
-            agreement_id: int
+            agreement_id    : int
         ) -> bool:
         query = """
             SELECT *
@@ -168,7 +168,11 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
 
     def persist_chapter_occurence(self, 
-            chapter_ref:str, book_map_id: int, translation_id: int, start_node: int=None, end_node: int=None
+            chapter_ref     :str, 
+            book_map_id     : int, 
+            translation_id  : int, 
+            start_node      : int = None, 
+            end_node        : int = None
         ) -> int:
         query = """
             INSERT INTO bible.chapteroccurences (chapter_ref, book_map_id, translation_id, start_node, end_node) 
@@ -179,10 +183,10 @@ class USXWriteBoundary(WriteBoundary):
         return chapter_occurence_id
     
     def persist_chapter(self, 
-            book_code: str, 
-            chapter_num: int, 
-            chapter_ref: str, 
-            is_standard: bool
+            book_code       : str, 
+            chapter_num     : int, 
+            chapter_ref     : str, 
+            is_standard     : bool
         ) -> None:
         query = """
             INSERT INTO bible.chapters (book_code, chapter_num, chapter_ref, standard) 
@@ -195,11 +199,11 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
 
     def persist_translation_info(self,
-            dbl_id: str,
-            revision: int,
-            is_supported: bool,
-            is_test_import: bool,
-            reason_not_supported: str = None
+            dbl_id                  : str,
+            revision                : int,
+            is_supported            : bool,
+            is_test_import          : bool,
+            reason_not_supported    : str = None
         ) -> None:
         # If we add this and we already have stored supported for translation revision, skip
         query = """
@@ -210,18 +214,18 @@ class USXWriteBoundary(WriteBoundary):
         self.db.execute(query, (dbl_id, revision, is_supported, is_test_import, reason_not_supported))
 
     def persist_usx_translation(self,
-            dbl_id: str,
-            revision: int,
-            revision_note: str,
-            revision_date: str,
-            language_id: int,
-            medium: str,
-            name: str,
-            name_local: str,
-            abbreviation: str,
-            abbreviationLocal: str,
-            copyright: str,
-            promotion: str,
+            dbl_id              : str,
+            revision            : int,
+            revision_note       : str,
+            revision_date       : str,
+            language_id         : int,
+            medium              : str,
+            name                : str,
+            name_local          : str,
+            abbreviation        : str,
+            abbreviationLocal   : str,
+            copyright           : str,
+            promotion           : str
         ) -> int:
         query = """
             INSERT INTO bible.translations (dbl_id, revision, revision_note, revision_date, language_id, medium, name, nameLocal, abbreviation, abbreviationLocal, copyright, promotion) 
@@ -232,11 +236,11 @@ class USXWriteBoundary(WriteBoundary):
         return translation_id
     
     def persist_translation_relation(self,
-            from_dbl_id: int,
-            from_revision: int,
-            to_dbl_id: str,
-            to_revision: str,
-            relation_type: str
+            from_dbl_id     : int,
+            from_revision   : int,
+            to_dbl_id       : str,
+            to_revision     : str,
+            relation_type   : str
         ) -> None:
         query = """
             INSERT INTO bible.translationrelationships (from_translation, from_revision, to_translation, to_revision, type) 
@@ -249,7 +253,7 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
 
     def persist_nodes(self, 
-            new_nodes: list[tuple]
+            new_nodes   : list[tuple]
         ) -> None:
         query = """
             INSERT INTO bible.nodes (node_text, node_type, code, sid, eid, vid, style, number, caller, closed, version, strong, loc, parent_node_id, index_in_parent, book_map_id, canonical_path, align, translation_id, is_tokenisable) 
@@ -262,10 +266,10 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
 
     def persist_paragraph(self, 
-            paragraph_node_id: int, 
-            style_id: int, 
-            is_versetext: bool,
-            parent_para_id: int = None
+            paragraph_node_id   : int, 
+            style_id            : int, 
+            is_versetext        : bool,
+            parent_para_id      : int = None
         ) -> int:
         query = """
             INSERT INTO bible.paragraphs (node_id, style_id, parent_para, is_versetext) 
@@ -280,13 +284,13 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
 
     def persit_dbl_agreement(self,
-            dbl_id: str,
-            agreement_id: int,
-            license_id: int,
-            dateLicensed: str,
-            dateLicenceExpires: str,
-            file_id: int,
-            active: bool
+            dbl_id              : str,
+            agreement_id        : int,
+            license_id          : int,
+            dateLicensed        : str,
+            dateLicenceExpires  : str,
+            file_id             : int,
+            active              : bool
         ) -> int:
         query = """
             INSERT INTO audit.dbl_agreements (dbl_id, agreement_id, license_id, date_licensed, date_licence_expires, file_id, active) 
@@ -297,7 +301,7 @@ class USXWriteBoundary(WriteBoundary):
         return dbl_agreement_id
     
     def init_agreement(self,
-            agreement_id: int
+            agreement_id    : int
         ) -> None:
         query = """
             INSERT INTO audit.dbl_agreements (agreement_id)
@@ -306,12 +310,12 @@ class USXWriteBoundary(WriteBoundary):
         self.db.execute(query, (agreement_id, ))
 
     def update_agreement(self, 
-            agreement_id: int,
-            dbl_id: str,
-            base_licence_id: int,
-            dateLicence: str,
-            dateLicenceExpiry: str,
-            licence_file_id: int
+            agreement_id        : int,
+            dbl_id              : str,
+            base_licence_id     : int,
+            dateLicence         : str,
+            dateLicenceExpiry   : str,
+            licence_file_id     : int
         ) -> None:
         query = """
             UPDATE audit.dbl_agreements 
@@ -325,8 +329,8 @@ class USXWriteBoundary(WriteBoundary):
         self.db.execute(query, (dbl_id, base_licence_id, dateLicence, dateLicenceExpiry, licence_file_id, agreement_id))
     
     def persist_agreement_revision_mapping(self,
-            agreement_id: int,
-            revision: int
+            agreement_id    : int,
+            revision        : int
         ) -> None:
         query = """
             INSERT INTO audit.dbl_revision_agreements (agreement_id, revision)
@@ -335,9 +339,9 @@ class USXWriteBoundary(WriteBoundary):
         self.db.execute(query, (agreement_id, revision))
 
     def persist_agreement_attributes(self,
-            agreement_id: int,
-            attribute_code: str,
-            attribute_value: str           
+            agreement_id        : int,
+            attribute_code      : str,
+            attribute_value     : str           
         ) -> None:
         query = """
             INSERT INTO audit.agreement_attributes (agreement_id, attribute_code, attribute_value)
@@ -350,10 +354,10 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
 
     def persist_translation_file(self,
-            file_id: int,
-            translation_id: int,
-            type: str,
-            version: str
+            file_id         : int,
+            translation_id  : int,
+            type            : str,
+            version         : str
         ) -> None:
         query = """
             INSERT INTO bible.translation_files (file_id, translation_id, type, version) 
@@ -363,11 +367,11 @@ class USXWriteBoundary(WriteBoundary):
 
     
     def persist_book_file(self,
-            book_code: str,
-            translation_id: int,
-            file_id: int,
-            short: str,
-            long: str
+            book_code       : str,
+            translation_id  : int,
+            file_id         : int,
+            short           : str,
+            long            : str
         ) -> int:
         query = """
             INSERT INTO bible.booktofile (book_code, translation_id, file_id, short, long) 
@@ -381,10 +385,10 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
     
     def persist_style_property(self,
-            name: str,
-            value: str,
-            unit: str = None,
-            style_id: int = None
+            name        : str,
+            value       : str,
+            unit        : str = None,
+            style_id    : int = None
         ) -> None:
         query = """
             INSERT INTO bible.properties (name, value, unit, style_id) 
@@ -393,12 +397,12 @@ class USXWriteBoundary(WriteBoundary):
         self.db.execute(query, (name, value, unit, style_id))
     
     def persist_style(self,
-            style: str,
-            name: str,
-            description: str,
-            is_versetext: bool,
-            is_publishable: bool,
-            source_file_id: int
+            style           : str,
+            name            : str,
+            description     : str,
+            is_versetext    : bool,
+            is_publishable  : bool,
+            source_file_id  : int
         ) -> int:
         query = """
             INSERT INTO bible.styles (style, name, description, versetext, publishable, source_file_id) 
@@ -413,8 +417,8 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
 
     def persist_excluded_verse(self,
-            verse_ref: str,
-            translation_id: int
+            verse_ref       : str,
+            translation_id  : int
         ) -> None:
         query = """
             INSERT INTO bible.excludedverses (verse_ref, translation_id) 
@@ -423,10 +427,10 @@ class USXWriteBoundary(WriteBoundary):
         self.db.execute(query, (verse_ref, translation_id))
 
     def persist_verse(self,
-            chapter_ref: str,
-            verse_ref: str,
-            verse: str,
-            is_standard: bool
+            chapter_ref : str,
+            verse_ref   : str,
+            verse       : str,
+            is_standard : bool
         ) -> int:
         query = """
             INSERT INTO bible.verses (chapter_ref, verse_ref, verse, standard) 
@@ -436,8 +440,8 @@ class USXWriteBoundary(WriteBoundary):
         return verse_id
     
     def persist_verse_correction(self,
-            non_standard_verse_ref: str,
-            verse_ref: str
+            non_standard_verse_ref  : str,
+            verse_ref               : str
         ) -> None:
         query = """
             INSERT INTO bible.verse_correction (non_standard_verse_ref, verse_ref) 
@@ -446,12 +450,12 @@ class USXWriteBoundary(WriteBoundary):
         self.db.execute(query, (non_standard_verse_ref, verse_ref))
     
     def persist_verse_occurence(self,
-            chapter_id: int,
-            book_map_id: int,
-            translation_id: int,
-            verse_ref: str,
-            start_node: int,
-            end_node: int
+            chapter_id      : int,
+            book_map_id     : int,
+            translation_id  : int,
+            verse_ref       : str,
+            start_node      : int,
+            end_node        : int
         ) -> int:
         query = """
             INSERT INTO bible.verseoccurences (chapter_id, book_map_id, translation_id, verse_ref, start_node, end_node) 
@@ -466,9 +470,9 @@ class USXWriteBoundary(WriteBoundary):
     # ============================================================================
     
     def persist_footnote(self,
-            node_id: int,
-            chapter_ref: str,
-            verse_ref: str
+            node_id         : int,
+            chapter_ref     : str,
+            verse_ref       : str
         ) -> int:
         query = """
             INSERT INTO bible.translationfootnotes (node_id, chapter_ref, verse_ref) 
@@ -479,11 +483,11 @@ class USXWriteBoundary(WriteBoundary):
         return footnote_id
     
     def persist_cross_reference(self,
-            node_id: int,
-            from_verse_ref: str,
-            to_verse_ref: str,
-            from_chapter_ref: str,
-            to_chapter_ref: str
+            node_id             : int,
+            from_verse_ref      : str,
+            to_verse_ref        : str,
+            from_chapter_ref    : str,
+            to_chapter_ref      : str
         ) -> int:
         query = """
             INSERT INTO bible.translationrefnotes (node_id, from_verse_ref, to_verse_ref, from_chapter_ref, to_chapter_ref) 
@@ -499,7 +503,7 @@ class USXDeleteBoundary(DeleteBoundary):
     # ============================================================================
 
     def delete_translation(self,
-            translation_id: int
+            translation_id  : int
         ) -> None:
         # Ideas is to cancel USX translation and all its derivative data
         query = """

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -10,6 +10,7 @@ CREATE TABLE sil.iso_scopes (
     description     TEXT NOT NULL
 );
 
+-- https://iso639-3.sil.org/about/scope
 INSERT INTO sil.iso_scopes (id, name, description)
 VALUES 
     ('I', 'Individual',     'Represents a single, distinct language'),
@@ -22,13 +23,14 @@ CREATE TABLE sil.iso_types (
     description     TEXT NOT NULL
 );
 
+-- https://iso639-3.sil.org/about/types
 INSERT INTO sil.iso_types (id, name, description)
 VALUES 
     ('A', 'Ancient',        'Known only from historical records'),
-    ('C', 'Constructed',    'Artificially created language'),
-    ('E', 'Extinct',        'No longer spoken'),
-    ('H', 'Histrical',      'Earlier form of a modern language'),
-    ('L', 'Living',         'Currently spoken'),
+    ('C', 'Constructed',    'This part of ISO 639 also includes identifiers that denote constructed (or artificial) languages. In order to qualify for inclusion the language must have a literature and it must be designed for the purpose of human communication. It must be a complete language, and be in use for human communication by some community long enough to be passed to a second generation of users. Specifically excluded are reconstructed languages and computer programming languages.'),
+    ('E', 'Extinct',        'A language is listed as extinct if it has gone extinct in recent times. (e.g. in the last few centuries). The criteria for identifying distinct languages in these cases are based on intelligibility (as defined for individual languages).'),
+    ('H', 'Histrical',      'A language is listed as historic when it is considered to be distinct from any modern languages that are descended from it: for instance, Old English and Middle English. In these cases, the language did not become extinct; rather, it changed into a different language over time. Here, too, the criterion is that the language have a literature that is treated distinctly by the scholarly community.'),
+    ('L', 'Living',         'A language is listed as living when there are people still living who learned it as a first language. This part of ISO 639 also includes identifiers for languages that are no longer living.'),
     ('S', 'Special',        'Special-use language code');
 
 CREATE TABLE sil.iso_codes (

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -14,7 +14,8 @@ INSERT INTO sil.iso_scopes (id, name, description)
 VALUES 
     ('I', 'Individual',     'Represents a single, distinct language'),
     ('M', 'Macrolanguage',  'Represents a macrolanguage rather than an individual language'),
-    ('S', 'Special',        'Reserved for special purposes (e.g. undetermined)');
+    ('S', 'Special',        'Reserved for special purposes (e.g. undetermined)'),
+    ('U', 'Unkwon',         'Scope unknown due to Retirement');
 
 CREATE TABLE sil.iso_types (
     id              char(1) PRIMARY KEY,
@@ -29,7 +30,8 @@ VALUES
     ('E', 'Extinct',        'No longer spoken'),
     ('H', 'Histrical',      'Earlier form of a modern language'),
     ('L', 'Living',         'Currently spoken'),
-    ('S', 'Special',        'Special-use language code');
+    ('S', 'Special',        'Special-use language code'),
+    ('U', 'Unknwon',        'Language Type unknown due to Retirement');
 
 -- Originally from 
 CREATE TABLE sil.iso_status (

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -14,8 +14,7 @@ INSERT INTO sil.iso_scopes (id, name, description)
 VALUES 
     ('I', 'Individual',     'Represents a single, distinct language'),
     ('M', 'Macrolanguage',  'Represents a macrolanguage rather than an individual language'),
-    ('S', 'Special',        'Reserved for special purposes (e.g. undetermined)'),
-    ('U', 'Unkwon',         'Scope unknown due to Retirement');
+    ('S', 'Special',        'Reserved for special purposes (e.g. undetermined)');
 
 CREATE TABLE sil.iso_types (
     id              char(1) PRIMARY KEY,
@@ -30,20 +29,7 @@ VALUES
     ('E', 'Extinct',        'No longer spoken'),
     ('H', 'Histrical',      'Earlier form of a modern language'),
     ('L', 'Living',         'Currently spoken'),
-    ('S', 'Special',        'Special-use language code'),
-    ('U', 'Unknwon',        'Language Type unknown due to Retirement');
-
--- Originally from 
-CREATE TABLE sil.iso_status (
-    id              char(1) PRIMARY KEY,
-    name            TEXT NOT NULL,
-    description     TEXT NOT NULL
-);
-
-INSERT INTO sil.iso_status (id, name, description)
-VALUES 
-    ('A', 'Active',     'Code is currently valid'),
-    ('R', 'Retired',    'Code has been retired');
+    ('S', 'Special',        'Special-use language code');
 
 CREATE TABLE sil.iso_codes (
     id          char(3) PRIMARY KEY,    -- The three-letter 639-3 identifier
@@ -53,11 +39,9 @@ CREATE TABLE sil.iso_codes (
     scope       char(1) NOT NULL, 
     type        char(1) NOT NULL,
     ref_name    varchar(150) NOT NULL,  -- Reference language name 
-    status      char(1) NOT NULL,
     comment     varchar(150),      -- Comment relating to one or more of the columns
     FOREIGN KEY (scope) REFERENCES sil.iso_scopes (id),
-    FOREIGN KEY (type) REFERENCES sil.iso_types (id),
-    FOREIGN KEY (status) REFERENCES sil.iso_status (id)
+    FOREIGN KEY (type) REFERENCES sil.iso_types (id)
 );
 
 -- ============================================================================
@@ -71,19 +55,6 @@ CREATE TABLE sil.iso_names (
     inverted_name   varchar(75) NOT NULL,   -- The inverted form of this Print_Name form   
     FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id)
 ); 
-
--- ============================================================================
--- ISO 639-3 Macrolanguage Codes
--- ============================================================================
-
-CREATE TABLE sil.macrolanguages (
-    macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
-    iso_id              char(3) NOT NULL,   -- The identifier for an individual language that is a member of the macrolanguage
-    iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
-    PRIMARY KEY (macro_id, iso_id),
-    FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
-    FOREIGN KEY (iso_status) REFERENCES sil.iso_status (id)
-);
 
 -- ============================================================================
 -- ISO 639-3 Retirements (A.K.A Depracated Codes)
@@ -121,4 +92,31 @@ CREATE TABLE sil.retirement_changes (
     changed_to          char(3) NOT NULL,          -- in the cases of C, D, and M (Retirement_Reason), the identifier to which all instances of this Id should be changed
     FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (retirement_id) REFERENCES sil.retirements (id)
-)
+);
+
+-- ============================================================================
+-- ISO 639-3 Macrolanguage Codes
+-- ============================================================================
+
+CREATE TABLE sil.iso_status (
+    id              char(1) PRIMARY KEY,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL
+);
+
+INSERT INTO sil.iso_status (id, name, description)
+VALUES 
+    ('A', 'Active',     'Code is currently valid'),
+    ('R', 'Retired',    'Code has been retired');
+
+CREATE TABLE sil.macrolanguages (
+    macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
+    iso_id              char(3),   -- The identifier for an individual language that is a member of the macrolanguage
+    retirement_id       INTEGER,
+    iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
+    PRIMARY KEY (macro_id, iso_id),
+    FOREIGN KEY (macro_id) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (retirement_id) REFERENCES sil.retirements(id),
+    FOREIGN KEY (iso_status) REFERENCES sil.iso_status (id)
+);

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -107,7 +107,6 @@ CREATE TABLE sil.retirements (
     retired_reason      char(1)      NOT NULL,
     retired_remedy      varchar(300) NULL,          -- The instructions for updating an instance of the retired (split) identifier
     effective           DATE         NOT NULL,       -- The date the retirement became effective
-    FOREIGN KEY (iso_code) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (retired_reason) REFERENCES sil.retirement_reasons (id)
 );
 

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -88,10 +88,12 @@ CREATE TABLE sil.retirements (
 
 CREATE TABLE sil.retirement_changes (
     id                  SERIAL PRIMARY KEY,
-    retirement_id       INTEGER NOT NULL,
-    changed_to          char(3) NOT NULL,          -- in the cases of C, D, and M (Retirement_Reason), the identifier to which all instances of this Id should be changed
-    FOREIGN KEY (changed_to) REFERENCES sil.iso_codes (id),
-    FOREIGN KEY (retirement_id) REFERENCES sil.retirements (id)
+    from_retirement     INTEGER NOT NULL,
+    to_iso_code         char(3),          -- in the cases of C, D, and M (Retirement_Reason), the identifier to which all instances of this Id should be changed
+    to_retirement       INTEGER,
+    FOREIGN KEY (to_iso_code) REFERENCES sil.iso_codes (id),
+    FOREIGN KEY (from_retirement) REFERENCES sil.retirements (id),
+    FOREIGN KEY (to_retirement) REFERENCES sil.retirements (id)
 );
 
 -- ============================================================================

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -112,11 +112,11 @@ VALUES
     ('R', 'Retired',    'Code has been retired');
 
 CREATE TABLE sil.macrolanguages (
+    id                  SERIAL PRIMARY KEY,
     macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
     iso_id              char(3),   -- The identifier for an individual language that is a member of the macrolanguage
     retirement_id       INTEGER,
     iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
-    PRIMARY KEY (macro_id, iso_id),
     FOREIGN KEY (macro_id) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
     FOREIGN KEY (retirement_id) REFERENCES sil.retirements(id),

--- a/services/database/server/schemas/sil/language_codes.sql
+++ b/services/database/server/schemas/sil/language_codes.sql
@@ -31,6 +31,18 @@ VALUES
     ('L', 'Living',         'Currently spoken'),
     ('S', 'Special',        'Special-use language code');
 
+-- Originally from 
+CREATE TABLE sil.iso_status (
+    id              char(1) PRIMARY KEY,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL
+);
+
+INSERT INTO sil.iso_status (id, name, description)
+VALUES 
+    ('A', 'Active',     'Code is currently valid'),
+    ('R', 'Retired',    'Code has been retired');
+
 CREATE TABLE sil.iso_codes (
     id          char(3) PRIMARY KEY,    -- The three-letter 639-3 identifier
     part2b      char(3) NULL,           -- Equivalent 639-2 identifier of the bibliographic applications (if there is one)
@@ -39,9 +51,11 @@ CREATE TABLE sil.iso_codes (
     scope       char(1) NOT NULL, 
     type        char(1) NOT NULL,
     ref_name    varchar(150) NOT NULL,  -- Reference language name 
-    comment     varchar(150) NULL,      -- Comment relating to one or more of the columns
+    status      char(1) NOT NULL,
+    comment     varchar(150),      -- Comment relating to one or more of the columns
     FOREIGN KEY (scope) REFERENCES sil.iso_scopes (id),
-    FOREIGN KEY (type) REFERENCES sil.iso_types (id)
+    FOREIGN KEY (type) REFERENCES sil.iso_types (id),
+    FOREIGN KEY (status) REFERENCES sil.iso_status (id)
 );
 
 -- ============================================================================
@@ -60,24 +74,13 @@ CREATE TABLE sil.iso_names (
 -- ISO 639-3 Macrolanguage Codes
 -- ============================================================================
 
-CREATE TABLE sil.macro_status (
-    id              char(1) PRIMARY KEY,
-    name            TEXT NOT NULL,
-    description     TEXT NOT NULL
-);
-
-INSERT INTO sil.macro_status (id, name, description)
-VALUES 
-    ('A', 'Active',     'Code is currently valid'),
-    ('R', 'Retired',    'Code has been retired');
-
 CREATE TABLE sil.macrolanguages (
     macro_id            char(3) NOT NULL,   -- The identifier for a macrolanguage
     iso_id              char(3) NOT NULL,   -- The identifier for an individual language that is a member of the macrolanguage
     iso_status          char(1) NOT NULL,   -- indicating the status of the individual code element
     PRIMARY KEY (macro_id, iso_id),
     FOREIGN KEY (iso_id) REFERENCES sil.iso_codes (id),
-    FOREIGN KEY (iso_status) REFERENCES sil.macro_status (id)
+    FOREIGN KEY (iso_status) REFERENCES sil.iso_status (id)
 );
 
 -- ============================================================================

--- a/services/database/server/seed/licensing_data.sql
+++ b/services/database/server/seed/licensing_data.sql
@@ -39,6 +39,7 @@ VALUES
     ('NO_TRADEMARK', 'No Trademark Use', 'Cannot use trademarks', 'RESTRICTION'),
     ('NO_PATENT', 'No Patent Grant', 'No patent rights granted', 'RESTRICTION'),
     ('NO_WARRANTY', 'No Warranty', 'Provided as-is without warranty', 'RESTRICTION'),
+    ('NO_DISTRIBUTION', 'No Distribution', 'Do not provide a means to redistribute', 'RESTRICTION'),
     
     -- ============================================================================
     -- DBL-SPECIFIC PUBLICATION RIGHTS (from your XML example: see any licence.xml)

--- a/services/database/server/seed/ref_lookup_data.sql
+++ b/services/database/server/seed/ref_lookup_data.sql
@@ -16,9 +16,10 @@ INSERT INTO lookup.data_formats (code, mime_type, extension, description) VALUES
     ('LDML', 'application/xml', 'ldml', 'Unicode Locale Data Markup Language');
 
 INSERT INTO lookup.source_types (code, name, description) VALUES 
-    ('PUB', 'Publisher', 'An organization or entity that officially publishes and releases biblical resources, datasets, or scholarly works. Publishers typically hold intellectual property rights and are responsible for the official release of materials.'),
-    ('DAT', 'Dataset', 'A structured collection of biblical data organized for a specific purpose, such as morphological analysis, lexical information, or textual variants. May be produced by publishers, contributors, or distributors.'),
-    ('FILE', 'File', 'An individual file containing biblical data or resources. May exist as part of a dataset or as a standalone resource. Represents the actual data artifact being processed or stored.'),
-    ('CONT', 'Contributor', 'An individual, organization, or scholarly entity that contributes to the creation, editing, translation, or annotation of biblical resources. Contributors may work on datasets without being the official publisher.'),
-    ('DIST', 'Distributor', 'An organization or platform that makes biblical resources available to users, potentially aggregating content from multiple publishers and contributors. Distributors facilitate access and delivery but may not hold original publishing rights.'),
-    ('LICP', 'Licence Provider', 'Licence standard creators');
+    ('PUB',     'Publisher',        'An organization or entity that officially publishes and releases biblical resources, datasets, or scholarly works. Publishers typically hold intellectual property rights and are responsible for the official release of materials.'),
+    ('DAT',     'Dataset',          'A structured collection of biblical data organized for a specific purpose, such as morphological analysis, lexical information, or textual variants. May be produced by publishers, contributors, or distributors.'),
+    ('FILE',    'File',             'An individual file containing biblical data or resources. May exist as part of a dataset or as a standalone resource. Represents the actual data artifact being processed or stored.'),
+    ('CONT',    'Contributor',      'An individual, organization, or scholarly entity that contributes to the creation, editing, translation, or annotation of biblical resources. Contributors may work on datasets without being the official publisher.'),
+    ('DIST',    'Distributor',      'An organization or platform that makes biblical resources available to users, potentially aggregating content from multiple publishers and contributors. Distributors facilitate access and delivery but may not hold original publishing rights.'),
+    ('LICP',    'Licence Provider', 'Licence standard creators'),
+    ('STAN',    'Standard',         'Responsible party for maintaining the standard of the source');

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -33,6 +33,8 @@ class SILIngestor:
             is_default      = True
         )
 
+        self.log.log_to_file(f"Created Bucket for SILL Data: [{self.obj.bucket}]", "INGESTOR", "INFO")
+
         self.read           = SILReadBoundary(self.db)
         self.write          = SILWriteBoundary(self.db)
 
@@ -49,6 +51,7 @@ class SILIngestor:
         self.get_latest_dowload_link()
 
         self.db.commit()
+        self.log.log_to_file(f"SIL Ingestion COMPLETE!", "INGESTOR", "INFO")
 
     def create_source(self):
         pass
@@ -70,6 +73,8 @@ class SILIngestor:
         
         final_link = link["href"]
 
+        self.log.log_to_file(f"Found Latest download at: [{final_link}]", "INGESTOR", "INFO")
+
         self.download(final_link)
 
     def download(self, link: str):
@@ -86,7 +91,7 @@ class SILIngestor:
                 if chunk:  # filter out keep-alive chunks
                     f.write(chunk)
 
-        self.log.log_to_file(f"Downloaded SIL Language Files to: {new_file_path}!", "INGESTOR", "INFO")
+        self.log.log_to_file(f"Downloaded Latest SIL Language Files to: {new_file_path}!", "INGESTOR", "INFO")
 
         self.create_source()
         self.unzip_folder(new_file_path)
@@ -94,6 +99,8 @@ class SILIngestor:
     def unzip_folder(self, zip_path):
         # This will unzip the zip folder, and then delete the original and replace process location with new path name
         downloads_location = Path(zip_path).parent
+
+        self.log.log_to_file(f"Unzipping File Contents ...", "INGESTOR", "INFO")
 
         with ZipFile(zip_path, 'r') as zip:
             # list all file paths in the ZIP
@@ -111,6 +118,7 @@ class SILIngestor:
             self.log.log_to_file(f"Unzipping [{len(all_files)}] files from {zip_path} in {new_location}", "TRANSLATION", "INFO")
 
             self.read_downloads(new_location)
+            self.log.log_to_file(f"Completed Ingestion of all files!", "INGESTOR", "INFO")
 
             self.delete_files(new_location)
 
@@ -202,6 +210,7 @@ class SILIngestor:
                     )
 
     def delete_files(self, file_location: Path):
+        self.log.log_to_file(f"Cleaning Up File Downloads ...", "INGESTOR", "INFO")
         if file_location.is_dir():
             shutil.rmtree(file_location, ignore_errors=True)  # delete folder + contents
         elif file_location.is_file():

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -46,8 +46,9 @@ class SILIngestor:
 
         self.source_id      = None
 
-        print("Testing")
         self.get_latest_dowload_link()
+
+        self.db.commit()
 
     def create_source(self):
         pass
@@ -85,7 +86,6 @@ class SILIngestor:
                 if chunk:  # filter out keep-alive chunks
                     f.write(chunk)
 
-        print("Download complete")
         self.log.log_to_file(f"Downloaded SIL Language Files to: {new_file_path}!", "INGESTOR", "INFO")
 
         self.create_source()

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -123,8 +123,8 @@ class SILIngestor:
         files = {
             0: "iso-639-3.tab",
             1: "iso-639-3_Name_Index.tab",
-            2: "iso-639-3-macrolanguages.tab",
-            3: "iso-639-3_Retirements.tab"
+            2: "iso-639-3_Retirements.tab",
+            3: "iso-639-3-macrolanguages.tab"
         }
 
         # Get latest part of the folder to get date it was recently uploaded, this will be object start
@@ -151,14 +151,14 @@ class SILIngestor:
                         file_path       = data_file_path
                     )
                 case 2:
-                    ISO6393MacroLanguages(
+                    ISO6393Retirements(
                         main_manager    = self.manager,
                         log             = self.log,
                         source_id       = self.source_id,
                         file_path       = data_file_path
                     )
                 case 3:
-                    ISO6393Retirements(
+                    ISO6393MacroLanguages(
                         main_manager    = self.manager,
                         log             = self.log,
                         source_id       = self.source_id,

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -60,22 +60,44 @@ class SILIngestor:
         parent_source = self.read.find_source("SIL")
 
         source_id = self.write.persist_source(
-            source_type     = "DAT", # Dataset
-            code            = "ISO6393",
-            name            = "ISO 639-3",
-            description     = "ISO 639 gives comprehensive provisions for the identification and assignment of language identifiers to individual languages, and for the creation of new language code elements or for the modification of existing ones",
-            version         = None,
-            url             = source_url,
-            note            = None,
-            parent_source   = parent_source,
+            source_type         = "DAT", # Dataset
+            code                = "ISO6393",
+            name                = "ISO 639-3",
+            description         = "ISO 639 gives comprehensive provisions for the identification and assignment of language identifiers to individual languages, and for the creation of new language code elements or for the modification of existing ones",
+            version             = None,
+            url                 = source_url,
+            note                = None,
+            parent_source       = parent_source,
+            official_citation   = """
+                ISO 639-3:2019. Codes for the Representation of Names of Languages — Part 3: Alpha-3 Code for Comprehensive Coverage of Languages.
+                Registration Authority: SIL International.
+                Available at: https://iso639-3.sil.org
+                © SIL International.
+            """
         )
 
         return source_id
 
-    # TO DO
     def map_license(self):
         # Maps licensing details to the files or at least the source for now
-        pass
+        licence_id = self.write.persist_licence(
+            source_id   = self.source_id,
+            code        = "SIL-ISO",
+            name        = "ISO 639-3 Terms of Use",
+            version     = None,
+            link        = "https://iso639-3.sil.org/code_tables/download_tables#termsofuse",
+            notes       = "CUSTOM TERMS OF USE"
+        )
+
+        licence_attributes = [
+            "ATTRIBUTION",
+            "NO_DERIVATIVES",
+            "NO_DISTRIBUTION"
+        ]
+        self.write.map_all_licence_attributes(
+            licence_id      = licence_id,
+            attributes      = licence_attributes
+        )
 
     def get_latest_dowload_link(self):
         DOWNLOAD_PAGE = "https://iso639-3.sil.org/code_tables/download_tables"

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -138,35 +138,67 @@ class SILIngestor:
             match id:
                 case 0:
                     # 7927 Entries
-                    ISO6393Codes(
+                    codes = ISO6393Codes(
                         main_manager    = self.manager,
                         log             = self.log,
                         source_id       = self.source_id,
                         file_path       = data_file_path
+                    )
+
+                    codes.upload_file(
+                        object_name     = f"{self.object_start}/{file}",
+                        file_path       = data_file_path,
+                        content_type    = "text/tab-separated-values",
+                        data_format     = "TSV",
+                        version_note    = f"{file_date}"
                     )
                 case 1:
                     # 8321 Entries
-                    ISO6393Names(
+                    names = ISO6393Names(
                         main_manager    = self.manager,
                         log             = self.log,
                         source_id       = self.source_id,
                         file_path       = data_file_path
+                    )
+
+                    names.upload_file(
+                        object_name     = f"{self.object_start}/{file}",
+                        file_path       = data_file_path,
+                        content_type    = "text/tab-separated-values",
+                        data_format     = "TSV",
+                        version_note    = f"{file_date}"
                     )
                 case 2:
                     # 386 Entries
-                    ISO6393Retirements(
+                    retirements = ISO6393Retirements(
                         main_manager    = self.manager,
                         log             = self.log,
                         source_id       = self.source_id,
                         file_path       = data_file_path
                     )
+
+                    retirements.upload_file(
+                        object_name     = f"{self.object_start}/{file}",
+                        file_path       = data_file_path,
+                        content_type    = "text/tab-separated-values",
+                        data_format     = "TSV",
+                        version_note    = f"{file_date}"
+                    )
                 case 3:
                     # 459 Entries
-                    ISO6393MacroLanguages(
+                    macroLanguages = ISO6393MacroLanguages(
                         main_manager    = self.manager,
                         log             = self.log,
                         source_id       = self.source_id,
                         file_path       = data_file_path
+                    )
+
+                    macroLanguages.upload_file(
+                        object_name     = f"{self.object_start}/{file}",
+                        file_path       = data_file_path,
+                        content_type    = "text/tab-separated-values",
+                        data_format     = "TSV",
+                        version_note    = f"{file_date}"
                     )
         
         # After wards they should be uploaded to object storage, and persisted to DB

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -137,6 +137,7 @@ class SILIngestor:
 
             match id:
                 case 0:
+                    # 7927 Entries
                     ISO6393Codes(
                         main_manager    = self.manager,
                         log             = self.log,
@@ -144,6 +145,7 @@ class SILIngestor:
                         file_path       = data_file_path
                     )
                 case 1:
+                    # 8321 Entries
                     ISO6393Names(
                         main_manager    = self.manager,
                         log             = self.log,
@@ -151,6 +153,7 @@ class SILIngestor:
                         file_path       = data_file_path
                     )
                 case 2:
+                    # 386 Entries
                     ISO6393Retirements(
                         main_manager    = self.manager,
                         log             = self.log,
@@ -158,6 +161,7 @@ class SILIngestor:
                         file_path       = data_file_path
                     )
                 case 3:
+                    # 459 Entries
                     ISO6393MacroLanguages(
                         main_manager    = self.manager,
                         log             = self.log,

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -27,7 +27,8 @@ class SILIngestor:
 
         self.log.log_to_file(f"SIL Ingestion starting ...", "INGESTOR", "INFO")
 
-        self.obj            = self.manager.get_obj().create_bucket(
+        self.obj            = self.manager.get_obj()
+        self.obj.create_bucket(
             bucket_name     = "reference-data",
             is_versioned    = True,
             is_default      = True

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -1,0 +1,158 @@
+from manager.managerhandler import ManagerHandler
+
+from ingestor.usx.files.base_file import BaseFile
+from database.boundary.sil_boundary import SILReadBoundary, SILWriteBoundary, SILDeleteBoundary
+
+import requests
+
+from zipfile import ZipFile
+import os
+from pathlib import Path
+import shutil
+from bs4 import BeautifulSoup
+
+class SILIngestor:
+    def __init__(self,
+            manager: ManagerHandler | None = None
+        ):
+        self.manager        = manager or ManagerHandler()
+        self.log            = self.manager.create_log_in_folder(["logs", "ingestor", "sil"], f"")
+        self.db             = self.manager.get_db()
+
+        self.log.set_logging_level(1)
+
+        self.log.log_to_file(f"SIL Ingestion starting ...", "INGESTOR", "INFO")
+
+        self.obj            = self.manager.get_obj().create_bucket(
+            bucket_name     = "reference-data",
+            is_versioned    = True,
+            is_default      = True
+        )
+
+        self.read           = SILReadBoundary(self.db)
+        self.write          = SILWriteBoundary(self.db)
+
+        self.object_start   = "SIL-data"
+
+        self.download_path  = Path(__file__).parents[2] / "downloads"
+        os.makedirs(self.download_path, exist_ok=True)
+
+        # Need playwright to visit so that the path will be the latest zip download file?
+        self.source_url     = None
+
+        self.source_id      = None
+
+        print("Testing")
+        self.get_latest_dowload_link()
+
+    def create_source(self):
+        pass
+
+    def map_license(self):
+        # Maps licensing details to the files or at least the source for now
+        pass
+
+    def get_latest_dowload_link(self):
+        DOWNLOAD_PAGE = "https://iso639-3.sil.org/code_tables/download_tables"
+
+        html = requests.get(DOWNLOAD_PAGE)
+        html.raise_for_status()
+
+        soup = BeautifulSoup(html.text, "html.parser")
+        link = soup.select_one('a[href*="iso-639-3_Code_Tables_"][href$=".zip"]')
+        if not link:
+            raise RuntimeError("Latest ISO 639-3 ZIP not found")
+        
+        final_link = link["href"]
+
+        self.download(final_link)
+
+    def download(self, link: str):
+        self.source_url = link
+
+        response = requests.get(link, stream=True)
+        response.raise_for_status()  # fail loudly if something goes wrong
+
+        filename = "sil_iso_data.zip"
+        new_file_path = self.download_path / filename
+
+        with open(new_file_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:  # filter out keep-alive chunks
+                    f.write(chunk)
+
+        print("Download complete")
+        self.log.log_to_file(f"Downloaded SIL Language Files to: {new_file_path}!", "INGESTOR", "INFO")
+
+        self.create_source()
+        self.unzip_folder(new_file_path)
+
+    def unzip_folder(self, zip_path):
+        # This will unzip the zip folder, and then delete the original and replace process location with new path name
+        downloads_location = Path(zip_path).parent
+
+        with ZipFile(zip_path, 'r') as zip:
+            # list all file paths in the ZIP
+            all_files   = zip.namelist()
+
+            # find the top-level folder (first part before '/')
+            top_levels  = {Path(f).parts[0] for f in all_files if '/' in f}
+            top_folder  = next(iter(top_levels)) if top_levels else None
+
+            # extract everything
+            zip.extractall(downloads_location)
+
+            # Saves the new location for the usx files to be ran in next part of pipeline
+            new_location = downloads_location / top_folder
+            self.log.log_to_file(f"Unzipping [{len(all_files)}] files from {zip_path} in {new_location}", "TRANSLATION", "INFO")
+
+            self.read_downloads(new_location)
+
+            self.delete_files(new_location)
+
+        # After unzipping delete the old zip file
+        shutil.rmtree(zip_path, ignore_errors=True)
+        self.delete_files(zip_path)
+
+    def read_downloads(self, file_path: Path):
+        # Goes through all the child files and loads them into the appropriate class to download accordingly
+        files = {
+            0: "iso-639-3_Name_Index.tab",
+            1: "iso-639-3_Retirements.tab",
+            2: "iso-639-3-macrolanguages.tab",
+            3: "iso-639-3.tab"
+        }
+
+        # Get latest part of the folder to get date it was recently uploaded, this will be object start
+        file_date = file_path.parts[-1].split("_")[-1]
+
+        # Can use versionig instead to set or access these files, so that its easier
+
+        for id, file in files.items():
+            data_file_path = file_path / file
+
+            match id:
+                case 0:
+                    pass
+                case 1:
+                    pass
+                case 2:
+                    pass
+                case 3:
+                    pass
+        
+        # After wards they should be uploaded to object storage, and persisted to DB
+
+        # Then everything should be good
+        pass
+
+    def delete_files(self, file_location: Path):
+        return
+        if file_location.is_dir():
+            shutil.rmtree(file_location, ignore_errors=True)  # delete folder + contents
+        elif file_location.is_file():
+            Path(file_location).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    SILIngestor()

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -200,19 +200,12 @@ class SILIngestor:
                         data_format     = "TSV",
                         version_note    = f"{file_date}"
                     )
-        
-        # After wards they should be uploaded to object storage, and persisted to DB
-
-        # Then everything should be good
-        pass
 
     def delete_files(self, file_location: Path):
-        return
         if file_location.is_dir():
             shutil.rmtree(file_location, ignore_errors=True)  # delete folder + contents
         elif file_location.is_file():
             Path(file_location).unlink(missing_ok=True)
-
 
 if __name__ == "__main__":
     SILIngestor()

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -53,9 +53,25 @@ class SILIngestor:
         self.db.commit()
         self.log.log_to_file(f"SIL Ingestion COMPLETE!", "INGESTOR", "INFO")
 
-    def create_source(self):
-        pass
+    def create_source(self,
+            source_url : str
+        ) -> int:
+        parent_source = self.read.find_source("SIL")
 
+        source_id = self.write.persist_source(
+            source_type     = "DAT", # Dataset
+            code            = "ISO6393",
+            name            = "ISO 639-3",
+            description     = "ISO 639 gives comprehensive provisions for the identification and assignment of language identifiers to individual languages, and for the creation of new language code elements or for the modification of existing ones",
+            version         = None,
+            url             = source_url,
+            note            = None,
+            parent_source   = parent_source,
+        )
+
+        return source_id
+
+    # TO DO
     def map_license(self):
         # Maps licensing details to the files or at least the source for now
         pass
@@ -93,7 +109,7 @@ class SILIngestor:
 
         self.log.log_to_file(f"Downloaded Latest SIL Language Files to: {new_file_path}!", "INGESTOR", "INFO")
 
-        self.create_source()
+        self.source_id = self.create_source(link)
         self.unzip_folder(new_file_path)
 
     def unzip_folder(self, zip_path):

--- a/services/ingestor/sil/ingestor.py
+++ b/services/ingestor/sil/ingestor.py
@@ -1,7 +1,11 @@
 from manager.managerhandler import ManagerHandler
 
-from ingestor.usx.files.base_file import BaseFile
 from database.boundary.sil_boundary import SILReadBoundary, SILWriteBoundary, SILDeleteBoundary
+
+from ingestor.sil.iso6393_codes import ISO6393Codes
+from ingestor.sil.iso6393_names import ISO6393Names
+from ingestor.sil.iso6393_macrolanguages import ISO6393MacroLanguages
+from ingestor.sil.iso6393_retirements import ISO6393Retirements
 
 import requests
 
@@ -117,10 +121,10 @@ class SILIngestor:
     def read_downloads(self, file_path: Path):
         # Goes through all the child files and loads them into the appropriate class to download accordingly
         files = {
-            0: "iso-639-3_Name_Index.tab",
-            1: "iso-639-3_Retirements.tab",
+            0: "iso-639-3.tab",
+            1: "iso-639-3_Name_Index.tab",
             2: "iso-639-3-macrolanguages.tab",
-            3: "iso-639-3.tab"
+            3: "iso-639-3_Retirements.tab"
         }
 
         # Get latest part of the folder to get date it was recently uploaded, this will be object start
@@ -133,13 +137,33 @@ class SILIngestor:
 
             match id:
                 case 0:
-                    pass
+                    ISO6393Codes(
+                        main_manager    = self.manager,
+                        log             = self.log,
+                        source_id       = self.source_id,
+                        file_path       = data_file_path
+                    )
                 case 1:
-                    pass
+                    ISO6393Names(
+                        main_manager    = self.manager,
+                        log             = self.log,
+                        source_id       = self.source_id,
+                        file_path       = data_file_path
+                    )
                 case 2:
-                    pass
+                    ISO6393MacroLanguages(
+                        main_manager    = self.manager,
+                        log             = self.log,
+                        source_id       = self.source_id,
+                        file_path       = data_file_path
+                    )
                 case 3:
-                    pass
+                    ISO6393Retirements(
+                        main_manager    = self.manager,
+                        log             = self.log,
+                        source_id       = self.source_id,
+                        file_path       = data_file_path
+                    )
         
         # After wards they should be uploaded to object storage, and persisted to DB
 

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -20,10 +20,15 @@ class ISO6393Codes(BaseFile):
         self.read           = SILReadBoundary(self.db)
         self.write          = SILWriteBoundary(self.db)
 
+        self.log.log_to_file(f"SIL Ingestion of Active ISO 639-3 Language Codes ...", "INGESTOR", "INFO")
+
         self.read_file()
 
     def read_file(self):
         added_codes = 0
+
+        self.log.log_to_file(f"Reading File ...", "INGESTOR", "INFO")
+
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Part2b', 'Part2t', 'Part1', 'Scope', 'Language_Type', 'Ref_Name', 'Comment']
             header = next(f).rstrip("\n").split("\t")
@@ -42,9 +47,10 @@ class ISO6393Codes(BaseFile):
                     comment     = columns[7]  # Comment
                 )
                 added_codes += 1
+                self.log.log_to_file(f"New ISO 639-3 Code: {columns}", "INGESTOR", "TRACE")
         
         print(f"Added [{added_codes}] New ISO 639-3 Codes")
-
+        self.log.log_to_file(f"Added [{added_codes}] New ISO 639-3 Codes", "INGESTOR", "INFO")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -39,7 +39,6 @@ class ISO6393Codes(BaseFile):
                     scope       = columns[4], # Scope
                     type        = columns[5], # Language_Type
                     ref_name    = columns[6], # Ref_Name
-                    status      = 'A',        # DEFAULT - All Iso Codes importer are active ones
                     comment     = columns[7]  # Comment
                 )
                 added_codes += 1

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -16,4 +16,27 @@ class ISO6393Codes(BaseFile):
         ):
         super().__init__(main_manager, log, source_id, file_path)
 
-        
+        self.read_file()
+
+    def read_file(self):
+        with open(self.this_file_path, "r", encoding="utf-8") as f:
+            # ['Id', 'Part2b', 'Part2t', 'Part1', 'Scope', 'Language_Type', 'Ref_Name', 'Comment']
+            header = next(f).rstrip("\n").split("\t")
+            
+            print(header)
+
+            for line in f:
+                columns = line.rstrip("\n").split("\t")
+                # print(columns)
+                # columns is now a list of values
+                
+if __name__ == "__main__":
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+    ISO6393Codes(
+        ManagerHandler(),
+        LogManager(),
+        0,
+        Path("/Users/cepherom/git/bible-insight-server/services/downloads/iso-639-3_Code_Tables_20260115/iso-639-3.tab")
+    )

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -1,0 +1,19 @@
+from ingestor.usx.files.base_file import BaseFile
+
+from pathlib import Path
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+class ISO6393Codes(BaseFile):
+    def __init__(self, 
+            main_manager: "ManagerHandler", 
+            log         : "LogManager", 
+            source_id   : int, 
+            file_path   : Path
+        ):
+        super().__init__(main_manager, log, source_id, file_path)
+
+        

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -1,4 +1,5 @@
 from ingestor.usx.files.base_file import BaseFile
+from database.boundary.sil_boundary import SILReadBoundary, SILWriteBoundary, SILDeleteBoundary
 
 from pathlib import Path
 
@@ -15,6 +16,9 @@ class ISO6393Codes(BaseFile):
             file_path   : Path
         ):
         super().__init__(main_manager, log, source_id, file_path)
+
+        self.read           = SILReadBoundary(self.db)
+        self.write          = SILWriteBoundary(self.db)
 
         self.read_file()
 

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -23,6 +23,7 @@ class ISO6393Codes(BaseFile):
         self.read_file()
 
     def read_file(self):
+        added_codes = 0
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Part2b', 'Part2t', 'Part1', 'Scope', 'Language_Type', 'Ref_Name', 'Comment']
             header = next(f).rstrip("\n").split("\t")
@@ -31,8 +32,21 @@ class ISO6393Codes(BaseFile):
 
             for line in f:
                 columns = line.rstrip("\n").split("\t")
-                # print(columns)
-                # columns is now a list of values
+
+                self.write.persist_iso_code(
+                    iso_code    = columns[0], # Id
+                    part2b      = columns[1], # Part2b
+                    part2t      = columns[2], # Part2t
+                    part1       = columns[3], # Part1
+                    scope       = columns[4], # Scope
+                    type        = columns[5], # Language_Type
+                    ref_name    = columns[6], # Ref_Name
+                    comment     = columns[7]  # Comment
+                )
+                added_codes += 1
+        
+        print(f"Added [{added_codes}] New ISO 639-3 Codes")
+
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -41,6 +41,7 @@ class ISO6393Codes(BaseFile):
                     scope       = columns[4], # Scope
                     type        = columns[5], # Language_Type
                     ref_name    = columns[6], # Ref_Name
+                    status      = 'A',        # DEFAULT - All Iso Codes importer are active ones
                     comment     = columns[7]  # Comment
                 )
                 added_codes += 1

--- a/services/ingestor/sil/iso6393_codes.py
+++ b/services/ingestor/sil/iso6393_codes.py
@@ -27,8 +27,6 @@ class ISO6393Codes(BaseFile):
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Part2b', 'Part2t', 'Part1', 'Scope', 'Language_Type', 'Ref_Name', 'Comment']
             header = next(f).rstrip("\n").split("\t")
-            
-            print(header)
 
             for line in f:
                 columns = line.rstrip("\n").split("\t")

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -1,4 +1,5 @@
 from ingestor.usx.files.base_file import BaseFile
+from database.boundary.sil_boundary import SILReadBoundary, SILWriteBoundary, SILDeleteBoundary
 
 from pathlib import Path
 
@@ -15,6 +16,9 @@ class ISO6393MacroLanguages(BaseFile):
             file_path   : Path
         ):
         super().__init__(main_manager, log, source_id, file_path)
+
+        self.read           = SILReadBoundary(self.db)
+        self.write          = SILWriteBoundary(self.db)
 
         self.read_file()
 

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -15,3 +15,28 @@ class ISO6393MacroLanguages(BaseFile):
             file_path   : Path
         ):
         super().__init__(main_manager, log, source_id, file_path)
+
+        self.read_file()
+
+    def read_file(self):
+        with open(self.this_file_path, "r", encoding="utf-8") as f:
+            # ['M_Id', 'I_Id', 'I_Status']
+            header = next(f).rstrip("\n").split("\t")
+            
+            print(header)
+
+            for line in f:
+                columns = line.rstrip("\n").split("\t")
+                # print(columns)
+                # columns is now a list of values
+                
+if __name__ == "__main__":
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+    ISO6393MacroLanguages(
+        ManagerHandler(),
+        LogManager(),
+        0,
+        Path("/Users/cepherom/git/bible-insight-server/services/downloads/iso-639-3_Code_Tables_20260115/iso-639-3-macrolanguages.tab")
+    )

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -20,10 +20,14 @@ class ISO6393MacroLanguages(BaseFile):
         self.read           = SILReadBoundary(self.db)
         self.write          = SILWriteBoundary(self.db)
 
+        self.log.log_to_file(f"SIL Ingestion of ISO 639-3 Macro Language Codes ...", "INGESTOR", "INFO")
+
         self.read_file()
 
     def read_file(self):
         added_macro_languages = 0
+
+        self.log.log_to_file(f"Reading File ...", "INGESTOR", "INFO")
 
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['M_Id', 'I_Id', 'I_Status']
@@ -42,6 +46,8 @@ class ISO6393MacroLanguages(BaseFile):
                         iso_status      = columns[2]  # I_Status
                     )
                     added_macro_languages += 1
+                    self.log.log_to_file(f"New Macro Language Code: {columns}", "INGESTOR", "TRACE")
+
                 else:
                     self.write.persist_iso_macrolanguage(
                         macro_id        = columns[0], # M_Id
@@ -50,8 +56,10 @@ class ISO6393MacroLanguages(BaseFile):
                         iso_status      = columns[2]  # I_Status
                     )
                     added_macro_languages += 1
+                    self.log.log_to_file(f"New Macro Language Code: {columns} -> Retirement ID [{retirement_id}]", "INGESTOR", "TRACE")
 
         print(f"Added [{added_macro_languages}] Macro Languages")
+        self.log.log_to_file(f"Added [{added_macro_languages}] New ISO 639-3 Macro Languages Codes", "INGESTOR", "INFO")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -24,6 +24,7 @@ class ISO6393MacroLanguages(BaseFile):
 
     def read_file(self):
         added_macro_languages = 0
+        added_iso_codes = 0
 
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['M_Id', 'I_Id', 'I_Status']
@@ -32,6 +33,7 @@ class ISO6393MacroLanguages(BaseFile):
             for line in f:
                 columns = line.rstrip("\n").split("\t")
                 
+                # 
                 if (self.read.is_iso_code(columns[1])):
                     self.write.persist_iso_macrolanguage(
                         macro_id    = columns[0], # M_Id
@@ -40,20 +42,23 @@ class ISO6393MacroLanguages(BaseFile):
                     )
                     added_macro_languages += 1
                 else:
-                    # If macro language retired, then insert that into iso_codes
-                    self.write.persist_iso_code(
-                        iso_code    = columns[0],   # Id
-                        part2b      = None,         # Part2b
-                        part2t      = None,         # Part2t
-                        part1       = None,         # Part1
-                        scope       = 'M',          # DEFAULT: Unknown -> Scope
-                        type        = 'U',          # DEFAULT: Unknown -> Language_Type
-                        ref_name    = 'UNKNOWN',    # Ref_Name
-                        status      = 'R',          # DEFAULT: Retired 
-                        comment     = 'DERIVED -> FROM Macrolanguages'  # Comment
-                    )
+                    
+                    if self.read.is_iso_code(columns[0]) == False:
+                        # If macro language retired, then insert that into iso_codes
+                        self.write.persist_iso_code(
+                            iso_code    = columns[0],   # Id
+                            part2b      = None,         # Part2b
+                            part2t      = None,         # Part2t
+                            part1       = None,         # Part1
+                            scope       = 'M',          # DEFAULT: Unknown -> Scope
+                            type        = 'U',          # DEFAULT: Unknown -> Language_Type
+                            ref_name    = 'UNKNOWN',    # Ref_Name
+                            status      = 'R',          # DEFAULT: Retired 
+                            comment     = 'DERIVED -> FROM Macrolanguages'  # Comment
+                        )
+                        added_iso_codes += 1
 
-        print(f"Added [{added_macro_languages}] Macro Languages")
+        print(f"Added [{added_macro_languages}] Macro Languages + [{added_iso_codes}] Retired ISO Codes (Macrolanguages)")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -28,8 +28,6 @@ class ISO6393MacroLanguages(BaseFile):
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['M_Id', 'I_Id', 'I_Status']
             header = next(f).rstrip("\n").split("\t")
-            
-            print(header)
 
             for line in f:
                 columns = line.rstrip("\n").split("\t")
@@ -42,7 +40,18 @@ class ISO6393MacroLanguages(BaseFile):
                     )
                     added_macro_languages += 1
                 else:
-                    print(columns)
+                    # If macro language retired, then insert that into iso_codes
+                    self.write.persist_iso_code(
+                        iso_code    = columns[0],   # Id
+                        part2b      = None,         # Part2b
+                        part2t      = None,         # Part2t
+                        part1       = None,         # Part1
+                        scope       = 'M',          # DEFAULT: Unknown -> Scope
+                        type        = 'U',          # DEFAULT: Unknown -> Language_Type
+                        ref_name    = 'UNKNOWN',    # Ref_Name
+                        status      = 'R',          # DEFAULT: Retired 
+                        comment     = 'DERIVED -> FROM Macrolanguages'  # Comment
+                    )
 
         print(f"Added [{added_macro_languages}] Macro Languages")
                 

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -24,7 +24,6 @@ class ISO6393MacroLanguages(BaseFile):
 
     def read_file(self):
         added_macro_languages = 0
-        added_iso_codes = 0
 
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['M_Id', 'I_Id', 'I_Status']
@@ -33,32 +32,26 @@ class ISO6393MacroLanguages(BaseFile):
             for line in f:
                 columns = line.rstrip("\n").split("\t")
                 
-                # 
-                if (self.read.is_iso_code(columns[1])):
+                #
+                retirement_id = self.read.get_retirement(columns[1])
+                if retirement_id == None:
                     self.write.persist_iso_macrolanguage(
-                        macro_id    = columns[0], # M_Id
-                        iso_id      = columns[1], # I_Id
-                        iso_status  = columns[2]  # I_Status
+                        macro_id        = columns[0], # M_Id
+                        iso_id          = columns[1], # I_Id
+                        retirement_id   = None,
+                        iso_status      = columns[2]  # I_Status
                     )
                     added_macro_languages += 1
                 else:
-                    
-                    if self.read.is_iso_code(columns[0]) == False:
-                        # If macro language retired, then insert that into iso_codes
-                        self.write.persist_iso_code(
-                            iso_code    = columns[0],   # Id
-                            part2b      = None,         # Part2b
-                            part2t      = None,         # Part2t
-                            part1       = None,         # Part1
-                            scope       = 'M',          # DEFAULT: Unknown -> Scope
-                            type        = 'U',          # DEFAULT: Unknown -> Language_Type
-                            ref_name    = 'UNKNOWN',    # Ref_Name
-                            status      = 'R',          # DEFAULT: Retired 
-                            comment     = 'DERIVED -> FROM Macrolanguages'  # Comment
-                        )
-                        added_iso_codes += 1
+                    self.write.persist_iso_macrolanguage(
+                        macro_id        = columns[0], # M_Id
+                        iso_id          = None, # I_Id
+                        retirement_id   = retirement_id,
+                        iso_status      = columns[2]  # I_Status
+                    )
+                    added_macro_languages += 1
 
-        print(f"Added [{added_macro_languages}] Macro Languages + [{added_iso_codes}] Retired ISO Codes (Macrolanguages)")
+        print(f"Added [{added_macro_languages}] Macro Languages")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -23,6 +23,8 @@ class ISO6393MacroLanguages(BaseFile):
         self.read_file()
 
     def read_file(self):
+        added_macro_languages = 0
+
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['M_Id', 'I_Id', 'I_Status']
             header = next(f).rstrip("\n").split("\t")
@@ -31,8 +33,18 @@ class ISO6393MacroLanguages(BaseFile):
 
             for line in f:
                 columns = line.rstrip("\n").split("\t")
-                # print(columns)
-                # columns is now a list of values
+                
+                if (self.read.is_iso_code(columns[1])):
+                    self.write.persist_iso_macrolanguage(
+                        macro_id    = columns[0], # M_Id
+                        iso_id      = columns[1], # I_Id
+                        iso_status  = columns[2]  # I_Status
+                    )
+                    added_macro_languages += 1
+                else:
+                    print(columns)
+
+        print(f"Added [{added_macro_languages}] Macro Languages")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_macrolanguages.py
+++ b/services/ingestor/sil/iso6393_macrolanguages.py
@@ -1,0 +1,17 @@
+from ingestor.usx.files.base_file import BaseFile
+
+from pathlib import Path
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+class ISO6393MacroLanguages(BaseFile):
+    def __init__(self, 
+            main_manager: "ManagerHandler", 
+            log         : "LogManager", 
+            source_id   : int, 
+            file_path   : Path
+        ):
+        super().__init__(main_manager, log, source_id, file_path)

--- a/services/ingestor/sil/iso6393_names.py
+++ b/services/ingestor/sil/iso6393_names.py
@@ -1,0 +1,17 @@
+from ingestor.usx.files.base_file import BaseFile
+
+from pathlib import Path
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+class ISO6393Names(BaseFile):
+    def __init__(self, 
+            main_manager: "ManagerHandler", 
+            log         : "LogManager", 
+            source_id   : int, 
+            file_path   : Path
+        ):
+        super().__init__(main_manager, log, source_id, file_path)

--- a/services/ingestor/sil/iso6393_names.py
+++ b/services/ingestor/sil/iso6393_names.py
@@ -23,16 +23,22 @@ class ISO6393Names(BaseFile):
         self.read_file()
 
     def read_file(self):
+        added_iso_code_names = 0
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Print_Name', 'Inverted_Name']
             header = next(f).rstrip("\n").split("\t")
-            
-            print(header)
 
             for line in f:
                 columns = line.rstrip("\n").split("\t")
-                # print(columns)
-                # columns is now a list of values
+                
+                self.write.persist_iso_names(
+                    iso_code        = columns[0],
+                    print_name      = columns[1],
+                    inverted_name   = columns[2]
+                )
+                added_iso_code_names += 1
+
+        print(f"Added [{added_iso_code_names}] Iso Code Names")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_names.py
+++ b/services/ingestor/sil/iso6393_names.py
@@ -20,10 +20,15 @@ class ISO6393Names(BaseFile):
         self.read           = SILReadBoundary(self.db)
         self.write          = SILWriteBoundary(self.db)
 
+        self.log.log_to_file(f"SIL Ingestion of Active ISO 639-3 Language Code Names ...", "INGESTOR", "INFO")
+
         self.read_file()
 
     def read_file(self):
         added_iso_code_names = 0
+
+        self.log.log_to_file(f"Reading File ...", "INGESTOR", "INFO")
+
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Print_Name', 'Inverted_Name']
             header = next(f).rstrip("\n").split("\t")
@@ -37,8 +42,11 @@ class ISO6393Names(BaseFile):
                     inverted_name   = columns[2]
                 )
                 added_iso_code_names += 1
+                self.log.log_to_file(f"New ISO 639-3 Code Name: {columns}", "INGESTOR", "TRACE")
 
         print(f"Added [{added_iso_code_names}] Iso Code Names")
+        self.log.log_to_file(f"Added [{added_iso_code_names}] New ISO 639-3 Code Names", "INGESTOR", "INFO")
+        
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_names.py
+++ b/services/ingestor/sil/iso6393_names.py
@@ -15,3 +15,28 @@ class ISO6393Names(BaseFile):
             file_path   : Path
         ):
         super().__init__(main_manager, log, source_id, file_path)
+
+        self.read_file()
+
+    def read_file(self):
+        with open(self.this_file_path, "r", encoding="utf-8") as f:
+            # ['Id', 'Print_Name', 'Inverted_Name']
+            header = next(f).rstrip("\n").split("\t")
+            
+            print(header)
+
+            for line in f:
+                columns = line.rstrip("\n").split("\t")
+                # print(columns)
+                # columns is now a list of values
+                
+if __name__ == "__main__":
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+    ISO6393Names(
+        ManagerHandler(),
+        LogManager(),
+        0,
+        Path("/Users/cepherom/git/bible-insight-server/services/downloads/iso-639-3_Code_Tables_20260115/iso-639-3_Name_Index.tab")
+    )

--- a/services/ingestor/sil/iso6393_names.py
+++ b/services/ingestor/sil/iso6393_names.py
@@ -1,4 +1,5 @@
 from ingestor.usx.files.base_file import BaseFile
+from database.boundary.sil_boundary import SILReadBoundary, SILWriteBoundary, SILDeleteBoundary
 
 from pathlib import Path
 
@@ -15,6 +16,9 @@ class ISO6393Names(BaseFile):
             file_path   : Path
         ):
         super().__init__(main_manager, log, source_id, file_path)
+
+        self.read           = SILReadBoundary(self.db)
+        self.write          = SILWriteBoundary(self.db)
 
         self.read_file()
 

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -37,16 +37,6 @@ class ISO6393Retirements(BaseFile):
                 # Tab separated values -> Array
                 columns = line.rstrip("\n").split("\t")
 
-                # Persist to database
-                retirement_id = self.write.persist_iso_retirements(
-                    iso_code        = columns[0], # Id
-                    ref_name        = columns[1], # Ref_Name
-                    retired_reason  = columns[2], # Ret_Reason
-                    retired_remedy  = columns[4], # Ret_Remedy
-                    effective       = columns[5]  # Effective
-                )
-                added_retirements += 1
-
                 self.write.persist_iso_code(
                     iso_code    = columns[0],   # Id
                     part2b      = None,         # Part2b
@@ -59,11 +49,30 @@ class ISO6393Retirements(BaseFile):
                     comment     = 'DERIVED -> FROM Retirements'  # Comment
                 )
                 added_iso_codes += 1
+
+        with open(self.this_file_path, "r", encoding="utf-8") as f:
+            # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
+            header = next(f).rstrip("\n").split("\t") # Skip Header line
+
+            # Go through file line by line
+            for line in f:
+                # Tab separated values -> Array
+                columns = line.rstrip("\n").split("\t")
+
+                # Persist to database
+                retirement_id = self.write.persist_iso_retirements(
+                    iso_code        = columns[0], # Id
+                    ref_name        = columns[1], # Ref_Name
+                    retired_reason  = columns[2], # Ret_Reason
+                    retired_remedy  = columns[4], # Ret_Remedy
+                    effective       = columns[5]  # Effective
+                )
+                added_retirements += 1
         
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
             header = next(f).rstrip("\n").split("\t") # Skip Header line
-            
+
             # Go through file line by line
             for line in f:
                 # Tab separated values -> Array
@@ -71,32 +80,40 @@ class ISO6393Retirements(BaseFile):
 
                 retirement_id = None
 
-                # Get retirement to link to first
-                if (not self.read.is_iso_code(columns[0])):
-                    retirement_id = self.read.get_retirement(columns[0])
-
-                print(retirement_id)
-                print(columns)
-
                 # Change codes mapped to retirement_id
                 if columns[3] != "":
-                    
-                    self.write.persist_iso_retirement_changes(
-                        retirement_id   = retirement_id,
-                        changed_to      = columns[3] # Change_To
-                    )
-                    added_change_codes += 1
+                    # Get retirement to link to first
+                    retirement_id = self.read.get_retirement(columns[0])
+                
+                    if retirement_id != None:
+                        print(retirement_id)
+
+                        self.write.persist_iso_retirement_changes(
+                            retirement_id   = retirement_id,
+                            changed_to      = columns[3] # Change_To
+                        )
+                        added_change_codes += 1
+                    else:
+                        print(columns)
+                        pass
 
                 # In the case of Ret_Reason 'S' - 'Split' it has all the new codes that the retired has been chaged to
                 #       within 
                 if columns[2] == 'S':
                     change_codes = re.findall(r"\[([^\]]+)\]", columns[4]) # Ret_Remedy
                     for code in change_codes:
-                        self.write.persist_iso_retirement_changes(
-                            retirement_id   = retirement_id,
-                            changed_to      = code
-                        )
-                        added_change_codes += 1
+                        # Get retirement to link to first
+                        retirement_id = self.read.get_retirement(code)
+
+                        if retirement_id != None:
+                            print(retirement_id)
+                            self.write.persist_iso_retirement_changes(
+                                retirement_id   = retirement_id,
+                                changed_to      = code
+                            )
+                            added_change_codes += 1
+                        else:
+                            print(columns)
             
         print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes + [{added_iso_codes}] Retired ISO Codes")
                 

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -1,0 +1,17 @@
+from ingestor.usx.files.base_file import BaseFile
+
+from pathlib import Path
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+class ISO6393Retirements(BaseFile):
+    def __init__(self, 
+            main_manager: "ManagerHandler", 
+            log         : "LogManager", 
+            source_id   : int, 
+            file_path   : Path
+        ):
+        super().__init__(main_manager, log, source_id, file_path)

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -37,28 +37,6 @@ class ISO6393Retirements(BaseFile):
                 # Tab separated values -> Array
                 columns = line.rstrip("\n").split("\t")
 
-                self.write.persist_iso_code(
-                    iso_code    = columns[0],   # Id
-                    part2b      = None,         # Part2b
-                    part2t      = None,         # Part2t
-                    part1       = None,         # Part1
-                    scope       = 'U',          # DEFAULT: Unknown -> Scope
-                    type        = 'U',          # DEFAULT: Unknown -> Language_Type
-                    ref_name    = columns[1],   # Ref_Name
-                    status      = 'R',          # DEFAULT: Retired 
-                    comment     = 'DERIVED -> FROM Retirements'  # Comment
-                )
-                added_iso_codes += 1
-
-        with open(self.this_file_path, "r", encoding="utf-8") as f:
-            # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
-            header = next(f).rstrip("\n").split("\t") # Skip Header line
-
-            # Go through file line by line
-            for line in f:
-                # Tab separated values -> Array
-                columns = line.rstrip("\n").split("\t")
-
                 # Persist to database
                 retirement_id = self.write.persist_iso_retirements(
                     iso_code        = columns[0], # Id
@@ -86,7 +64,7 @@ class ISO6393Retirements(BaseFile):
                     retirement_id = self.read.get_retirement(columns[0])
                 
                     if retirement_id != None:
-                        print(retirement_id)
+                        # print(retirement_id)
 
                         self.write.persist_iso_retirement_changes(
                             retirement_id   = retirement_id,

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -47,13 +47,23 @@ class ISO6393Retirements(BaseFile):
                 added_retirements += 1
 
                 # Change codes mapped to retirement_id
-                change_codes = re.findall(r"\[([^\]]+)\]", columns[3]) # Change_To
-                for code in change_codes:
+                if columns[3] != "":
                     self.write.persist_iso_retirement_changes(
                         retirement_id   = retirement_id,
-                        changed_to      = code
+                        changed_to      = columns[3] # Change_To
                     )
                     added_change_codes += 1
+
+                # In the case of Ret_Reason 'S' - 'Split' it has all the new codes that the retired has been chaged to
+                #       within 
+                if columns[2] == 'S':
+                    change_codes = re.findall(r"\[([^\]]+)\]", columns[4]) # Ret_Remedy
+                    for code in change_codes:
+                        self.write.persist_iso_retirement_changes(
+                            retirement_id   = retirement_id,
+                            changed_to      = code
+                        )
+                        added_change_codes += 1
             
         print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes")
                 

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -26,7 +26,6 @@ class ISO6393Retirements(BaseFile):
     def read_file(self):
         added_retirements = 0
         added_change_codes = 0
-        added_iso_codes = 0
 
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
@@ -56,24 +55,13 @@ class ISO6393Retirements(BaseFile):
                 # Tab separated values -> Array
                 columns = line.rstrip("\n").split("\t")
 
-                retirement_id = None
-
                 # Change codes mapped to retirement_id
                 if columns[3] != "":
                     # Get retirement to link to first
-                    retirement_id = self.read.get_retirement(columns[0])
-                
-                    if retirement_id != None:
-                        # print(retirement_id)
-
-                        self.write.persist_iso_retirement_changes(
-                            retirement_id   = retirement_id,
-                            changed_to      = columns[3] # Change_To
-                        )
-                        added_change_codes += 1
-                    else:
-                        print(columns)
-                        pass
+                    added_change_codes += self.create_retirement_changes(
+                        from_iso    = columns[0],
+                        to_iso      = columns[3] # Change_To
+                    )
 
                 # In the case of Ret_Reason 'S' - 'Split' it has all the new codes that the retired has been chaged to
                 #       within 
@@ -81,19 +69,44 @@ class ISO6393Retirements(BaseFile):
                     change_codes = re.findall(r"\[([^\]]+)\]", columns[4]) # Ret_Remedy
                     for code in change_codes:
                         # Get retirement to link to first
-                        retirement_id = self.read.get_retirement(code)
-
-                        if retirement_id != None:
-                            print(retirement_id)
-                            self.write.persist_iso_retirement_changes(
-                                retirement_id   = retirement_id,
-                                changed_to      = code
-                            )
-                            added_change_codes += 1
-                        else:
-                            print(columns)
+                        added_change_codes += self.create_retirement_changes(
+                            from_iso    = columns[0],
+                            to_iso      = code
+                        )
             
-        print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes + [{added_iso_codes}] Retired ISO Codes")
+        print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes")
+
+    def create_retirement_changes(self, 
+            from_iso : str, 
+            to_iso: str
+        ):
+        added_change_codes = 0
+
+        from_retirement = self.read.get_retirement(from_iso)
+        
+        if from_retirement != None:
+            to_retirement = self.read.get_retirement(to_iso)
+
+            if to_retirement == None:
+                self.write.persist_iso_retirement_changes(
+                    from_retirement     = from_retirement,
+                    to_iso_code         = to_iso,
+                    to_retirement       = None
+                )
+                
+            else:
+                self.write.persist_iso_retirement_changes(
+                    from_retirement     = from_retirement,
+                    to_iso_code         = None,
+                    to_retirement       = to_retirement
+                )
+
+            added_change_codes += 1
+        else:
+            print(to_iso)
+            pass
+
+        return added_change_codes
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -2,6 +2,7 @@ from ingestor.usx.files.base_file import BaseFile
 from database.boundary.sil_boundary import SILReadBoundary, SILWriteBoundary, SILDeleteBoundary
 
 from pathlib import Path
+import re
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -23,16 +24,38 @@ class ISO6393Retirements(BaseFile):
         self.read_file()
 
     def read_file(self):
+        added_retirements = 0
+        added_change_codes = 0
+
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
-            header = next(f).rstrip("\n").split("\t")
-            
-            print(header)
+            header = next(f).rstrip("\n").split("\t") # Skip Header line
 
+            # Go through file line by line
             for line in f:
+                # Tab separated values -> Array
                 columns = line.rstrip("\n").split("\t")
-                # print(columns)
-                # columns is now a list of values
+
+                # Persist to database
+                retirement_id = self.write.persist_iso_retirements(
+                    iso_code        = columns[0], # Id
+                    ref_name        = columns[1], # Ref_Name
+                    retired_reason  = columns[2], # Ret_Reason
+                    retired_remedy  = columns[4], # Ret_Remedy
+                    effective       = columns[5]  # Effective
+                )
+                added_retirements += 1
+
+                # Change codes mapped to retirement_id
+                change_codes = re.findall(r"\[([^\]]+)\]", columns[3]) # Change_To
+                for code in change_codes:
+                    self.write.persist_iso_retirement_changes(
+                        retirement_id   = retirement_id,
+                        changed_to      = code
+                    )
+                    added_change_codes += 1
+            
+        print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -15,3 +15,28 @@ class ISO6393Retirements(BaseFile):
             file_path   : Path
         ):
         super().__init__(main_manager, log, source_id, file_path)
+
+        self.read_file()
+
+    def read_file(self):
+        with open(self.this_file_path, "r", encoding="utf-8") as f:
+            # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
+            header = next(f).rstrip("\n").split("\t")
+            
+            print(header)
+
+            for line in f:
+                columns = line.rstrip("\n").split("\t")
+                # print(columns)
+                # columns is now a list of values
+                
+if __name__ == "__main__":
+    from manager.managerhandler import ManagerHandler
+    from manager.logmanager import LogManager
+
+    ISO6393Retirements(
+        ManagerHandler(),
+        LogManager(),
+        0,
+        Path("/Users/cepherom/git/bible-insight-server/services/downloads/iso-639-3_Code_Tables_20260115/iso-639-3_Retirements.tab")
+    )

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -1,4 +1,5 @@
 from ingestor.usx.files.base_file import BaseFile
+from database.boundary.sil_boundary import SILReadBoundary, SILWriteBoundary, SILDeleteBoundary
 
 from pathlib import Path
 
@@ -15,6 +16,9 @@ class ISO6393Retirements(BaseFile):
             file_path   : Path
         ):
         super().__init__(main_manager, log, source_id, file_path)
+
+        self.read           = SILReadBoundary(self.db)
+        self.write          = SILWriteBoundary(self.db)
 
         self.read_file()
 

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -46,6 +46,18 @@ class ISO6393Retirements(BaseFile):
                 )
                 added_retirements += 1
 
+                self.write.persist_iso_code(
+                    iso_code    = columns[0],   # Id
+                    part2b      = None,         # Part2b
+                    part2t      = None,         # Part2t
+                    part1       = None,         # Part1
+                    scope       = 'U',          # DEFAULT: Unknown -> Scope
+                    type        = 'U',          # DEFAULT: Unknown -> Language_Type
+                    ref_name    = columns[1],   # Ref_Name
+                    status      = 'R',          # DEFAULT: Retired 
+                    comment     = 'DERIVED -> FROM Retirements'  # Comment
+                )
+
                 # Change codes mapped to retirement_id
                 if columns[3] != "":
                     self.write.persist_iso_retirement_changes(

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -21,11 +21,15 @@ class ISO6393Retirements(BaseFile):
         self.read           = SILReadBoundary(self.db)
         self.write          = SILWriteBoundary(self.db)
 
+        self.log.log_to_file(f"SIL Ingestion of Active ISO 639-3 Language Code Retirements ...", "INGESTOR", "INFO")
+
         self.read_file()
 
     def read_file(self):
         added_retirements = 0
         added_change_codes = 0
+
+        self.log.log_to_file(f"Reading File ...", "INGESTOR", "INFO")
 
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
@@ -45,6 +49,7 @@ class ISO6393Retirements(BaseFile):
                     effective       = columns[5]  # Effective
                 )
                 added_retirements += 1
+                self.log.log_to_file(f"New ISO 639-3 Code Retirement: ID [{retirement_id}] -> {columns}", "INGESTOR", "TRACE")
         
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
@@ -57,24 +62,28 @@ class ISO6393Retirements(BaseFile):
 
                 # Change codes mapped to retirement_id
                 if columns[3] != "":
+                    self.log.log_to_file(f"New ISO 639-3 Standard Code Change: {columns[0]} -> {columns[3]}", "INGESTOR", "TRACE")
                     # Get retirement to link to first
                     added_change_codes += self.create_retirement_changes(
                         from_iso    = columns[0],
                         to_iso      = columns[3] # Change_To
                     )
-
+                
                 # In the case of Ret_Reason 'S' - 'Split' it has all the new codes that the retired has been chaged to
                 #       within 
                 if columns[2] == 'S':
                     change_codes = re.findall(r"\[([^\]]+)\]", columns[4]) # Ret_Remedy
                     for code in change_codes:
+                        self.log.log_to_file(f"New ISO 639-3 Split Code Change: {columns[0]} -> {code}", "INGESTOR", "TRACE")
                         # Get retirement to link to first
                         added_change_codes += self.create_retirement_changes(
                             from_iso    = columns[0],
                             to_iso      = code
                         )
-            
+                        
         print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes")
+        self.log.log_to_file(f"Added [{added_retirements}] New ISO 639-3 Retirements + [{added_change_codes}] ISO 639-3 Code Changes", "INGESTOR", "INFO")
+        
 
     def create_retirement_changes(self, 
             from_iso : str, 
@@ -100,11 +109,11 @@ class ISO6393Retirements(BaseFile):
                     to_iso_code         = None,
                     to_retirement       = to_retirement
                 )
+                self.log.log_to_file(f"New ISO 639-3 Split Code Retired: {from_iso} -> {to_iso} -> Retirement [{to_retirement}]", "INGESTOR", "TRACE")
 
             added_change_codes += 1
         else:
-            print(to_iso)
-            pass
+            self.log.log_to_file(f"New ISO 639-3 Code Change SKIPPED: {from_iso} -> {to_iso}", "INGESTOR", "DEBUG")
 
         return added_change_codes
                 

--- a/services/ingestor/sil/iso6393_retirements.py
+++ b/services/ingestor/sil/iso6393_retirements.py
@@ -26,6 +26,7 @@ class ISO6393Retirements(BaseFile):
     def read_file(self):
         added_retirements = 0
         added_change_codes = 0
+        added_iso_codes = 0
 
         with open(self.this_file_path, "r", encoding="utf-8") as f:
             # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
@@ -57,9 +58,29 @@ class ISO6393Retirements(BaseFile):
                     status      = 'R',          # DEFAULT: Retired 
                     comment     = 'DERIVED -> FROM Retirements'  # Comment
                 )
+                added_iso_codes += 1
+        
+        with open(self.this_file_path, "r", encoding="utf-8") as f:
+            # ['Id', 'Ref_Name', 'Ret_Reason', 'Change_To', 'Ret_Remedy', 'Effective']
+            header = next(f).rstrip("\n").split("\t") # Skip Header line
+            
+            # Go through file line by line
+            for line in f:
+                # Tab separated values -> Array
+                columns = line.rstrip("\n").split("\t")
+
+                retirement_id = None
+
+                # Get retirement to link to first
+                if (not self.read.is_iso_code(columns[0])):
+                    retirement_id = self.read.get_retirement(columns[0])
+
+                print(retirement_id)
+                print(columns)
 
                 # Change codes mapped to retirement_id
                 if columns[3] != "":
+                    
                     self.write.persist_iso_retirement_changes(
                         retirement_id   = retirement_id,
                         changed_to      = columns[3] # Change_To
@@ -77,7 +98,7 @@ class ISO6393Retirements(BaseFile):
                         )
                         added_change_codes += 1
             
-        print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes")
+        print(f"Added [{added_retirements}] Retirements + [{added_change_codes}] Change Codes + [{added_iso_codes}] Retired ISO Codes")
                 
 if __name__ == "__main__":
     from manager.managerhandler import ManagerHandler


### PR DESCRIPTION
# What
Adds ingestion support for SIL ISO 639-3 language codes.

# Why
This ingestion acts as a foundational dependency for all language-related data used by Bible Insight.

By importing the official ISO 639-3 standard, the system can reliably identify, distinguish, and reference languages using an established, transferable taxonomy. This avoids creating a custom or implicit language standard that would be tightly coupled to DBL USX metadata or other source-specific conventions, and instead ensures maximum compatibility with external systems and datasets.

# Notes
- Learned that object storage buckets cannot contain underscores (_); dashes (-) are now used as the separator instead.